### PR TITLE
Display WooCommerce messages on missing pages

### DIFF
--- a/content.php
+++ b/content.php
@@ -11,6 +11,15 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
+	<?php
+	/**
+	 * primer_before_content hook.
+	 *
+	 * @since 1.0.0
+	 */
+	do_action( 'primer_before_content' );
+	?>
+
 	<?php if ( ! is_single() || ! primer_use_featured_hero_image() ) : ?>
 
 		<?php get_template_part( 'templates/parts/loop/post', 'thumbnail' ); ?>
@@ -40,4 +49,12 @@
 
 	<?php get_template_part( 'templates/parts/loop/post', 'footer' ); ?>
 
+	<?php
+	/**
+	 * primer_after_content hook.
+	 *
+	 * @since 1.0.0
+	 */
+	do_action( 'primer_after_content' );
+	?>
 </article><!-- #post-## -->

--- a/content.php
+++ b/content.php
@@ -13,13 +13,13 @@
 
 	<?php
 	/**
-	 * primer_before_content hook.
+	 * Fires inside the `article` element, before the content.
 	 *
-	 * @hooked primer_woo_shop_message - 10
+	 * @hooked primer_woo_shop_messages - 10
 	 *
 	 * @since 1.0.0
 	 */
-	do_action( 'primer_before_content' );
+	do_action( 'primer_before_post_content' );
 	?>
 
 	<?php if ( ! is_single() || ! primer_use_featured_hero_image() ) : ?>
@@ -53,10 +53,11 @@
 
 	<?php
 	/**
-	 * primer_after_content hook.
+	 * Fires inside the `article` element, after the content.
 	 *
 	 * @since 1.0.0
 	 */
-	do_action( 'primer_after_content' );
+	do_action( 'primer_after_post_content' );
 	?>
+
 </article><!-- #post-## -->

--- a/content.php
+++ b/content.php
@@ -15,6 +15,8 @@
 	/**
 	 * primer_before_content hook.
 	 *
+	 * @hooked primer_woo_shop_message - 10
+	 *
 	 * @since 1.0.0
 	 */
 	do_action( 'primer_before_content' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -152,7 +152,7 @@ add_action( 'primer_after_header', 'primer_add_page_title' );
 /**
  * Display post meta template.
  *
- * @action primer_after_post_title_template
+ * @action primer_after_loop_post_template
  * @since 1.0.0
  */
 function primer_add_post_meta() {
@@ -160,7 +160,7 @@ function primer_add_post_meta() {
 	get_template_part( 'templates/parts/loop/post', 'meta' );
 
 }
-add_action( 'primer_after_post_title_template', 'primer_add_post_meta' );
+add_action( 'primer_after_loop_post_template', 'primer_add_post_meta' );
 
 /**
  * Display widget areas in the footer.

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -152,7 +152,7 @@ add_action( 'primer_after_header', 'primer_add_page_title' );
 /**
  * Display post meta template.
  *
- * @action primer_after_loop_post_template
+ * @action primer_after_post_title_template
  * @since 1.0.0
  */
 function primer_add_post_meta() {
@@ -160,7 +160,7 @@ function primer_add_post_meta() {
 	get_template_part( 'templates/parts/loop/post', 'meta' );
 
 }
-add_action( 'primer_after_loop_post_template', 'primer_add_post_meta' );
+add_action( 'primer_after_post_title_template', 'primer_add_post_meta' );
 
 /**
  * Display widget areas in the footer.

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -77,13 +77,18 @@ add_filter( 'theme_mod_layout', 'primer_woo_shop_layout' );
 /**
  * Display the shop messages on the page
  *
- * @return string
+ * @return mixed
+ *
+ * @since 1.0.0
  */
-function primer_woo_shop_message() {
+function primer_woo_shop_messages() {
 
 	if ( function_exists( 'is_checkout' ) && ! is_checkout() ) {
+
 		echo wp_kses_post( do_shortcode( '[woocommerce_messages]' ) );
+
 	}
 
 }
-add_action( 'primer_before_content', 'primer_woo_shop_message', 10 );
+add_action( 'primer_before_page_content', 'primer_woo_shop_messages' );
+add_action( 'primer_before_post_content', 'primer_woo_shop_messages' );

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -73,3 +73,39 @@ function primer_woo_shop_layout( $layout ) {
 
 }
 add_filter( 'theme_mod_layout', 'primer_woo_shop_layout' );
+
+/**
+ * Filter the page title for the WooCommerce shop page.
+ *
+ * @param  string $title
+ *
+ * @return string
+ */
+function primer_woo_shop_title( $title ) {
+
+	if ( function_exists( 'wc_get_page_id' ) && function_exists( 'is_shop' ) && is_shop() ) {
+
+		$title = get_the_title( wc_get_page_id( 'shop' ) );
+
+		// Remove the WooCommerce shop loop title
+		add_filter( 'woocommerce_page_title', 'primer_woo_shop_loop_title' );
+
+	}
+
+	return $title;
+
+}
+add_filter( 'primer_the_page_title', 'primer_woo_shop_title' );
+
+/**
+ * Filter the page title for the WooCommerce page.
+ *
+ * @param  string $title
+ *
+ * @return null
+ */
+function primer_woo_shop_loop_title( $title ) {
+
+	return;
+
+}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -73,39 +73,3 @@ function primer_woo_shop_layout( $layout ) {
 
 }
 add_filter( 'theme_mod_layout', 'primer_woo_shop_layout' );
-
-/**
- * Filter the page title for the WooCommerce shop page.
- *
- * @param  string $title
- *
- * @return string
- */
-function primer_woo_shop_title( $title ) {
-
-	if ( function_exists( 'wc_get_page_id' ) && function_exists( 'is_shop' ) && is_shop() ) {
-
-		$title = get_the_title( wc_get_page_id( 'shop' ) );
-
-		// Remove the WooCommerce shop loop title
-		add_filter( 'woocommerce_page_title', 'primer_woo_shop_loop_title' );
-
-	}
-
-	return $title;
-
-}
-add_filter( 'primer_the_page_title', 'primer_woo_shop_title' );
-
-/**
- * Filter the page title for the WooCommerce page.
- *
- * @param  string $title
- *
- * @return null
- */
-function primer_woo_shop_loop_title( $title ) {
-
-	return;
-
-}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -81,7 +81,7 @@ add_filter( 'theme_mod_layout', 'primer_woo_shop_layout' );
  */
 function primer_woo_shop_message() {
 
-	if ( ! is_checkout() ) {
+	if ( function_exists( 'is_checkout' ) && ! is_checkout() ) {
 		echo wp_kses_post( do_shortcode( '[woocommerce_messages]' ) );
 	}
 

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -73,3 +73,17 @@ function primer_woo_shop_layout( $layout ) {
 
 }
 add_filter( 'theme_mod_layout', 'primer_woo_shop_layout' );
+
+/**
+ * Display the shop messages on the page
+ *
+ * @return string
+ */
+function primer_woo_shop_message() {
+
+	if ( ! is_checkout() ) {
+		echo wp_kses_post( do_shortcode( '[woocommerce_messages]' ) );
+	}
+
+}
+add_action( 'primer_before_content', 'primer_woo_shop_message', 10 );

--- a/templates/parts/loop/page-content.php
+++ b/templates/parts/loop/page-content.php
@@ -10,6 +10,11 @@
 
 	<?php
 
+	/**
+	 * primer_before_content hook.
+	 */
+	do_action( 'primer_before_content' );
+
 	the_content();
 
 	wp_link_pages(
@@ -18,6 +23,11 @@
 			'after'  => '</div>',
 		)
 	);
+
+	/**
+	 * primer_after_content hook.
+	 */
+	do_action( 'primer_after_content' );
 
 	?>
 

--- a/templates/parts/loop/page-content.php
+++ b/templates/parts/loop/page-content.php
@@ -11,13 +11,13 @@
 	<?php
 
 	/**
-	 * primer_before_content hook.
+	 * Fires inside the `.page-content` element, before the content.
 	 *
-	 * @hooked primer_woo_shop_message - 10
+	 * @hooked primer_woo_shop_messages - 10
 	 *
 	 * @since 1.0.0
 	 */
-	do_action( 'primer_before_content' );
+	do_action( 'primer_before_page_content' );
 
 	the_content();
 
@@ -29,11 +29,11 @@
 	);
 
 	/**
-	 * primer_after_content hook.
+	* Fires inside the `.page-content` element, after the content.
 	 *
 	 * @since 1.0.0
 	 */
-	do_action( 'primer_after_content' );
+	do_action( 'primer_after_page_content' );
 
 	?>
 

--- a/templates/parts/loop/page-content.php
+++ b/templates/parts/loop/page-content.php
@@ -12,6 +12,10 @@
 
 	/**
 	 * primer_before_content hook.
+	 *
+	 * @hooked primer_woo_shop_message - 10
+	 *
+	 * @since 1.0.0
 	 */
 	do_action( 'primer_before_content' );
 
@@ -26,6 +30,8 @@
 
 	/**
 	 * primer_after_content hook.
+	 *
+	 * @since 1.0.0
 	 */
 	do_action( 'primer_after_content' );
 


### PR DESCRIPTION
Fixes #89 

This patch introduces two new actions, `primer_before_content` and `primer_after_content`, and adds them to the necessary page and post templates. The new hook, `primer_before_content`, is used to display the WooCommerce notices back to the user.

Introducing new actions is the best way to go, since the WooCommerce messages are displayed via shortcode which can't be prepended using `the_content` filter.

Pages and post page templates are constructed slightly differently, so the location of the actions may need slight tweaking.
