### PR TITLE
Add WooCommerce button/.sale support to color array

### DIFF
--- a/inc/customizer/colors.php
+++ b/inc/customizer/colors.php
@@ -333,9 +333,9 @@ class Primer_Customizer_Colors {
 						input[type="button"], input[type="button"]:hover, input[type="button"]:active, input[type="button"]:focus,
 						input[type="reset"], input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
 						input[type="submit"], input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
-						.woocommerce a.button,  .woocommerce a.button:hover,
 						.woocommerce button.button.alt, .woocommerce button.button.alt:hover,
-						.woocommerce a.button.alt, .woocommerce a.button.alt:hover,
+						.woocommerce a.button, .woocommerce a.button:visited, .woocommerce a.button:hover, .woocommerce a.button:visited:hover,
+						.woocommerce a.button.alt, .woocommerce a.button.alt:visited, .woocommerce a.button.alt:hover, .woocommerce a.button.alt:visited:hover,
 						.woocommerce .product span.onsale' => array(
 							'color' => '%1$s',
 						),

--- a/inc/customizer/colors.php
+++ b/inc/customizer/colors.php
@@ -299,7 +299,9 @@ class Primer_Customizer_Colors {
 						input[type="button"],
 						input[type="reset"],
 						input[type="submit"],
-						.woocommerce a.button, .woocommerce button.button.alt' => array(
+						.woocommerce a.button,
+						.woocommerce button.button.alt,
+						.woocommerce a.button.alt' => array(
 							'background-color' => '%1$s',
 							'border-color'     => '%1$s',
 						),
@@ -312,7 +314,8 @@ class Primer_Customizer_Colors {
 						input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
 						input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
 						.woocommerce a.button:hover, .woocommerce a.button:active, .woocommerce a.button:focus,
-						.woocommerce button.button.alt:hover, .woocommerce button.button.alt:active, .woocommerce button.button.alt:focus' => array(
+						.woocommerce button.button.alt:hover, .woocommerce button.button.alt:active, .woocommerce button.button.alt:focus,
+						.woocommerce a.button.alt:hover, .woocommerce a.button.alt:active, .woocommerce a.button.alt:focus' => array(
 							'background-color' => 'rgba(%1$s, 0.8)',
 							'border-color'     => 'rgba(%1$s, 0.8)',
 						),
@@ -330,7 +333,8 @@ class Primer_Customizer_Colors {
 						input[type="reset"], input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
 						input[type="submit"], input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
 						.woocommerce a.button,  .woocommerce a.button:hover,
-						.woocommerce button.button.alt, .woocommerce button.button.alt:hover' => array(
+						.woocommerce button.button.alt, .woocommerce button.button.alt:hover,
+						.woocommerce a.button.alt, .woocommerce a.button.alt:hover' => array(
 							'color' => '%1$s',
 						),
 					),

--- a/inc/customizer/colors.php
+++ b/inc/customizer/colors.php
@@ -298,7 +298,8 @@ class Primer_Customizer_Colors {
 						.content-area .fl-builder-content a.fl-button, .content-area .fl-builder-content a.fl-button:visited,
 						input[type="button"],
 						input[type="reset"],
-						input[type="submit"]' => array(
+						input[type="submit"],
+						.woocommerce a.button, .woocommerce button.button.alt' => array(
 							'background-color' => '%1$s',
 							'border-color'     => '%1$s',
 						),
@@ -309,7 +310,9 @@ class Primer_Customizer_Colors {
 						.content-area .fl-builder-content a.fl-button:hover, .content-area .fl-builder-content a.fl-button:active, .content-area .fl-builder-content a.fl-button:focus, .content-area .fl-builder-content a.fl-button:visited:hover, .content-area .fl-builder-content a.fl-button:visited:active, .content-area .fl-builder-content a.fl-button:visited:focus,
 						input[type="button"]:hover, input[type="button"]:active, input[type="button"]:focus,
 						input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
-						input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus' => array(
+						input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
+						.woocommerce a.button:hover, .woocommerce a.button:active, .woocommerce a.button:focus,
+						.woocommerce button.button.alt:hover, .woocommerce button.button.alt:active, .woocommerce button.button.alt:focus' => array(
 							'background-color' => 'rgba(%1$s, 0.8)',
 							'border-color'     => 'rgba(%1$s, 0.8)',
 						),
@@ -325,7 +328,9 @@ class Primer_Customizer_Colors {
 						a.fl-button, .content-area .fl-builder-content a.fl-button, .content-area .fl-builder-content a.fl-button:visited, .content-area .fl-builder-content a.fl-button *, .content-area .fl-builder-content a.fl-button:visited *, a.fl-button:hover, a.fl-button:active, a.fl-button:focus, a.fl-button:visited, a.fl-button:visited:hover, a.fl-button:visited:active, a.fl-button:visited:focus,
 						input[type="button"], input[type="button"]:hover, input[type="button"]:active, input[type="button"]:focus,
 						input[type="reset"], input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
-						input[type="submit"], input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus' => array(
+						input[type="submit"], input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
+						.woocommerce a.button,  .woocommerce a.button:hover,
+						.woocommerce button.button.alt, .woocommerce button.button.alt:hover' => array(
 							'color' => '%1$s',
 						),
 					),
@@ -377,7 +382,7 @@ class Primer_Customizer_Colors {
 					'default' => '#0b3954',
 					'section' => 'colors-menu',
 					'css'     => array(
-						'.main-navigation-container, .main-navigation.open, .main-navigation ul ul, .main-navigation .sub-menu' => array(
+						'.main-navigation-container, .main-navigation.open, .main-navigation ul ul, .main-navigation .sub-menu, .woocommerce .product span.onsale' => array(
 							'background-color' => '%1$s',
 						),
 					),

--- a/inc/customizer/colors.php
+++ b/inc/customizer/colors.php
@@ -301,7 +301,8 @@ class Primer_Customizer_Colors {
 						input[type="submit"],
 						.woocommerce a.button,
 						.woocommerce button.button.alt,
-						.woocommerce a.button.alt' => array(
+						.woocommerce a.button.alt,
+						.woocommerce .product span.onsale' => array(
 							'background-color' => '%1$s',
 							'border-color'     => '%1$s',
 						),
@@ -334,7 +335,8 @@ class Primer_Customizer_Colors {
 						input[type="submit"], input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
 						.woocommerce a.button,  .woocommerce a.button:hover,
 						.woocommerce button.button.alt, .woocommerce button.button.alt:hover,
-						.woocommerce a.button.alt, .woocommerce a.button.alt:hover' => array(
+						.woocommerce a.button.alt, .woocommerce a.button.alt:hover,
+						.woocommerce .product span.onsale' => array(
 							'color' => '%1$s',
 						),
 					),
@@ -386,7 +388,7 @@ class Primer_Customizer_Colors {
 					'default' => '#0b3954',
 					'section' => 'colors-menu',
 					'css'     => array(
-						'.main-navigation-container, .main-navigation.open, .main-navigation ul ul, .main-navigation .sub-menu, .woocommerce .product span.onsale' => array(
+						'.main-navigation-container, .main-navigation.open, .main-navigation ul ul, .main-navigation .sub-menu' => array(
 							'background-color' => '%1$s',
 						),
 					),


### PR DESCRIPTION
Fixes #87 and #86 

I've added the necessary elements to the colors array. I attempted to pass things through the filter in the `woocommerce.php` compat file, but it wasn't working until I re-initialized the `Primer_Customizer_Colors` class.

This was the cleanest solution, although users not using WooCommerce will not need support for these styles.

The .sale icon was set to match the nav background color, which maps well with the color schemes.
