### PR TITLE
Remove z-index on page titles

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -58,7 +58,6 @@ body.no-max-width .site-header-wrapper {
 		@include container($container-size);
 
 		position: relative;
-		z-index: 9999;
 		clear: both;
 
 		h1 {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1602,7 +1602,6 @@ body.no-max-width .site-header-wrapper {
     margin-right: auto;
     margin-left: auto;
     position: relative;
-    z-index: 9999;
     clear: both; }
     .page-title-container .page-header:after {
       content: " ";

--- a/style.css
+++ b/style.css
@@ -1602,7 +1602,6 @@ body.no-max-width .site-header-wrapper {
     margin-left: auto;
     margin-right: auto;
     position: relative;
-    z-index: 9999;
     clear: both; }
     .page-title-container .page-header:after {
       content: " ";


### PR DESCRIPTION
Fixes #104 

Removes z-index on page titles, which were taking priority over the mobile navigation.
