### PR TITLE
Update .onsale badges for i18n

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -5,3 +5,8 @@
 .woocommerce-page .primer-woocommerce .cart .qty {
 	padding: 0.18em;
 }
+
+body.post-type-archive span.onsale,
+body.single-product span.onsale {
+	padding: 0;
+}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,14 +1,14 @@
 .woocommerce-page {
 
-		/* 2 Column Layout */
-		ul.products li.product.primer-2-column-product {
-			width: 48.05%;
-		}
+	/* 2 Column Layout */
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
 
-		/* Quantity field */
-		.primer-woocommerce .cart .qty {
-			padding: 0.18em;
-		}
+	/* Quantity field */
+	.primer-woocommerce .cart .qty {
+		padding: 0.18em;
+	}
 
 }
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -16,8 +16,24 @@ body.post-type-archive,
 body.single-product {
 
 	/* On sale badge */
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
+}
+
+body.single-product {
+
 	span.onsale {
-		padding: 0;
+		padding: 3px 18px;
+		top: 0;
+		left: 0;
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,12 +1,23 @@
-.woocommerce-page ul.products li.product.primer-2-column-product {
-	width: 48.05%;
+.woocommerce-page {
+
+		/* 2 Column Layout */
+		ul.products li.product.primer-2-column-product {
+			width: 48.05%;
+		}
+
+		/* Quantity field */
+		.primer-woocommerce .cart .qty {
+			padding: 0.18em;
+		}
+
 }
 
-.woocommerce-page .primer-woocommerce .cart .qty {
-	padding: 0.18em;
-}
+body.post-type-archive,
+body.single-product {
 
-body.post-type-archive span.onsale,
-body.single-product span.onsale {
-	padding: 0;
+	/* On sale badge */
+	span.onsale {
+		padding: 0;
+	}
+
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2166,5 +2166,18 @@ body.post-type-archive,
 body.single-product {
   /* On sale badge */ }
   body.post-type-archive span.onsale,
-  body.single-product span.onsale {
-    padding: 0; }
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  right: 0; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2154,12 +2154,17 @@ body.no-max-width .site-info-wrapper .site-info {
 /*--------------------------------------------------------------
 # Compatibility
 --------------------------------------------------------------*/
-.woocommerce-page ul.products li.product.primer-2-column-product {
-  width: 48.05%; }
+.woocommerce-page {
+  /* 2 Column Layout */
+  /* Quantity field */ }
+  .woocommerce-page ul.products li.product.primer-2-column-product {
+    width: 48.05%; }
+  .woocommerce-page .primer-woocommerce .cart .qty {
+    padding: 0.18em; }
 
-.woocommerce-page .primer-woocommerce .cart .qty {
-  padding: 0.18em; }
-
-body.post-type-archive span.onsale,
-body.single-product span.onsale {
-  padding: 0; }
+body.post-type-archive,
+body.single-product {
+  /* On sale badge */ }
+  body.post-type-archive span.onsale,
+  body.single-product span.onsale {
+    padding: 0; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2159,3 +2159,7 @@ body.no-max-width .site-info-wrapper .site-info {
 
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.18em; }
+
+body.post-type-archive span.onsale,
+body.single-product span.onsale {
+  padding: 0; }

--- a/style.css
+++ b/style.css
@@ -2154,12 +2154,17 @@ body.no-max-width .site-info-wrapper .site-info {
 /*--------------------------------------------------------------
 # Compatibility
 --------------------------------------------------------------*/
-.woocommerce-page ul.products li.product.primer-2-column-product {
-  width: 48.05%; }
+.woocommerce-page {
+  /* 2 Column Layout */
+  /* Quantity field */ }
+  .woocommerce-page ul.products li.product.primer-2-column-product {
+    width: 48.05%; }
+  .woocommerce-page .primer-woocommerce .cart .qty {
+    padding: 0.18em; }
 
-.woocommerce-page .primer-woocommerce .cart .qty {
-  padding: 0.18em; }
-
-body.post-type-archive span.onsale,
-body.single-product span.onsale {
-  padding: 0; }
+body.post-type-archive,
+body.single-product {
+  /* On sale badge */ }
+  body.post-type-archive span.onsale,
+  body.single-product span.onsale {
+    padding: 0; }

--- a/style.css
+++ b/style.css
@@ -2159,3 +2159,7 @@ body.no-max-width .site-info-wrapper .site-info {
 
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.18em; }
+
+body.post-type-archive span.onsale,
+body.single-product span.onsale {
+  padding: 0; }

--- a/style.css
+++ b/style.css
@@ -2166,5 +2166,18 @@ body.post-type-archive,
 body.single-product {
   /* On sale badge */ }
   body.post-type-archive span.onsale,
-  body.single-product span.onsale {
-    padding: 0; }
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  left: 0; }


### PR DESCRIPTION
Fixes #106 

This PR adjusts the onsale badges to be rectangular, which works around the issue for circular badges in languages other than English.

My original thought was to remove the padding, to resolve the un-even circles. Setting padding to 0 made the circles a perfect circle. When the language was set to something other than English, this did not work.

As a solution, I think setting the sale badges to rectangular resolves both the uneven circles, and the i18n issue for circular .sale badges.

Shop Page Badge:
![WooCommerce Shop Page New Sale Badge](https://cldup.com/BdwWuYXmua.png)

Single Product Page Badge:
![WooCommerce Single Product Page New Sale Badge](https://cldup.com/GeN5bDQ4VD.png)

German Shop Page Badge:
![WooCommerce Shop Page German Sale Badge](https://cldup.com/x9u_ZPSEF5.png)

German Single Product Page Badge:
![WooCommerce Single Page German Sale Badge](https://cldup.com/41QVtUAy0b.png)
