### PR TITLE
Add branding to the admin footer, linking back to GoDaddy.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -526,7 +526,7 @@ function primer_admin_footer_link( $footer_text ) {
 
 	$additional_text = sprintf(
 		_x(
-			'%1$s built by <a href="%2$s" target="_blank">GoDaddy</a>.',
+			'%1$s Theme by <a href="%2$s" target="_blank">GoDaddy</a>.',
 			'First: The active theme name. Second: URL to Godaddy.',
 			'primer'
 		),

--- a/functions.php
+++ b/functions.php
@@ -526,7 +526,7 @@ function primer_admin_footer_link( $footer_text ) {
 
 	$additional_text = sprintf(
 		_x(
-			'%1$s Theme built by <a href="%2$s" target="_blank">GoDaddy</a>.',
+			'%1$s built by <a href="%2$s" target="_blank">GoDaddy</a>.',
 			'First: The active theme name. Second: URL to Godaddy.',
 			'primer'
 		),

--- a/functions.php
+++ b/functions.php
@@ -511,3 +511,19 @@ add_action( 'create_category', 'primer_has_active_categories_reset' );
 add_action( 'edit_category',   'primer_has_active_categories_reset' );
 add_action( 'delete_category', 'primer_has_active_categories_reset' );
 add_action( 'save_post',       'primer_has_active_categories_reset' );
+
+/**
+ * Link back to GoDaddy in the Admin Footer
+ *
+ * @return mixed
+ *
+ * @since 1.0.0
+ */
+function primer_admin_footer_link( $footer_text ) {
+
+	$text = sprintf( __( 'Primer Theme built by <a href="%s" target="_blank">GoDaddy</a>.' ), __( 'https://www.godaddy.com/' ) );
+
+	return wp_kses_post( $footer_text . ' | <span>' . $text . '</span>' );
+
+}
+add_filter( 'admin_footer_text', 'primer_admin_footer_link' );

--- a/functions.php
+++ b/functions.php
@@ -521,9 +521,20 @@ add_action( 'save_post',       'primer_has_active_categories_reset' );
  */
 function primer_admin_footer_link( $footer_text ) {
 
-	$text = sprintf( __( 'Primer Theme built by <a href="%s" target="_blank">GoDaddy</a>.' ), __( 'https://www.godaddy.com/' ) );
+	// Get the active theme name
+	$theme_name = wp_get_theme();
 
-	return wp_kses_post( $footer_text . ' | <span>' . $text . '</span>' );
+	$additional_text = sprintf(
+		_x(
+			'%1$s Theme built by <a href="%2$s" target="_blank">GoDaddy</a>.',
+			'First: The active theme name. Second: URL to Godaddy.',
+			'primer'
+		),
+		$theme_name,
+		__( 'https://www.godaddy.com/' )
+	);
+
+	return wp_kses_post( $footer_text . ' | <span>' . $additional_text . '</span>' );
 
 }
 add_filter( 'admin_footer_text', 'primer_admin_footer_link' );


### PR DESCRIPTION
I thought it might be nice to have some branding in the footer of the admin section, linking back to GoDaddy. This could be something we implement on sites not hosted on GoDaddy.

Not necessarily a requirement, but something I thought could enhance branding, increase links back to GoDaddy and remind users of the awesome team who built the theme they are using.

Example:
![Primer Footer Branding Example](https://cldup.com/N-6NZWzGbo.png)
