### PR TITLE
Add the widget form labels to the footer widget text color array

### DIFF
--- a/inc/customizer/colors.php
+++ b/inc/customizer/colors.php
@@ -229,7 +229,8 @@ class Primer_Customizer_Colors {
 					'section'         => 'colors-footer',
 					'active_callback' => 'primer_has_active_footer_sidebars',
 					'css'             => array(
-						'.site-footer .widget' => array(
+						'.site-footer .widget,
+						.site-footer .widget form label' => array(
 							'color' => '%1$s',
 						),
 					),


### PR DESCRIPTION
Footer widget form labels inherit the colors from the footer widget text color in the customizer. 

Fixes the following outstanding issues in child themes:
https://github.com/godaddy/wp-velux-theme/issues/29
https://github.com/godaddy/wp-stout-theme/issues/16
https://github.com/godaddy/wp-lyrical-theme/issues/30
