### PR TITLE
Fixed comments meta

### DIFF
--- a/templates/parts/loop/post-meta.php
+++ b/templates/parts/loop/post-meta.php
@@ -21,11 +21,7 @@
 
 		<span class="comments-number">
 
-				<a href="<?php echo get_comments_link(); ?>">
-
-					<span class="comments-link"><?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), esc_html_x( '% Comments', 'number of comments', 'primer' ) ); ?></span>
-
-				</a>
+			<?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), esc_html_x( '% Comments', 'number of comments', 'primer' ), 'comments-link' ); ?>
 
 		</span>
 


### PR DESCRIPTION
Was previously creating a link inside a link - https://cl.ly/2g1G0c0K2Y0R - and move the comments-link class inside the comments_popup_link for better WP standards.
