### PR TITLE
Add author credit toggle to site identity section of the customizer.

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -43,6 +43,13 @@ class Primer_Customizer {
 		 */
 		require_once get_template_directory() . '/inc/customizer/layouts.php';
 
+		/**
+		 * Load additional site identity options
+		 *
+		 * @since 1.4.2
+		 */
+		require_once get_template_directory() . '/inc/customizer/site-identity.php';
+
 		add_action( 'after_setup_theme',      array( $this, 'logo' ) );
 		add_action( 'customize_register',     array( $this, 'selective_refresh' ), 11 );
 		add_action( 'customize_register',     array( $this, 'use_featured_hero_image' ) );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -46,7 +46,7 @@ class Primer_Customizer {
 		/**
 		 * Load additional site identity options
 		 *
-		 * @since 1.4.2
+		 * @since NEXT
 		 */
 		require_once get_template_directory() . '/inc/customizer/site-identity.php';
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -31,7 +31,7 @@ class Primer_Site_Identity_Options {
 	 * @action primer_author_credit
 	 * @since 1.4.2
 	 *
-	 * @return boolean true|false based on site option
+	 * @return boolean true|false based on theme mod
 	 */
 	public function toggle_primer_author_credit() {
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -42,7 +42,7 @@ class Primer_Site_Identity_Options {
 	 */
 	public function toggle_primer_author_credit() {
 
-		return get_theme_mod( 'primer_author_credit' ) ? true : false;
+		return get_theme_mod( 'show_author_credit' ) ? true : false;
 
 	}
 
@@ -57,9 +57,10 @@ class Primer_Site_Identity_Options {
 	public function customize_register( WP_Customize_Manager $wp_customize ) {
 
 		$wp_customize->add_setting(
-			'primer_author_credit',
+			'show_author_credit',
 			array(
-				'default' => 1,
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
 			)
 		);
 
@@ -68,8 +69,9 @@ class Primer_Site_Identity_Options {
 			array(
 				'label'    => esc_html__( 'Display theme author credit', 'primer' ),
 				'section'  => 'title_tagline',
-				'settings' => 'primer_author_credit',
+				'settings' => 'show_author_credit',
 				'type'     => 'checkbox',
+				'priority' => 40,
 			)
 		);
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -64,7 +64,7 @@ class Primer_Site_Identity_Options {
 		$wp_customize->add_control(
 			'page_width',
 			array(
-				'label'       => esc_html__( 'Display theme author credits', 'primer' ),
+				'label'       => esc_html__( 'Display theme author credit', 'primer' ),
 				'section'     => 'title_tagline',
 				'settings'    => 'primer_author_credit',
 				'type'        => 'checkbox',

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -13,7 +13,12 @@ class Primer_Site_Identity_Options {
 	 */
 	public function __construct() {
 
-		if ( ! apply_filters( 'primer_expose_site_identity_settings', true ) ) {
+		/**
+		 * Disable additional site identity options
+		 *
+		 * @since 1.4.2
+		 */
+		if ( ! (bool) apply_filters( 'primer_show_site_identity_settings', true ) ) {
 
 			return;
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -13,7 +13,7 @@ class Primer_Site_Identity_Options {
 	 */
 	public function __construct() {
 
-		if ( class_exists( 'WPaaS\Log\Components\Plugin' ) && WPaaS\Plugin::is_reseller() ) {
+		if ( ! apply_filters( 'primer_expose_site_identity_settings', true ) ) {
 
 			return;
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -66,10 +66,10 @@ class Primer_Site_Identity_Options {
 		$wp_customize->add_control(
 			'page_width',
 			array(
-				'label'       => esc_html__( 'Display theme author credit', 'primer' ),
-				'section'     => 'title_tagline',
-				'settings'    => 'primer_author_credit',
-				'type'        => 'checkbox',
+				'label'    => esc_html__( 'Display theme author credit', 'primer' ),
+				'section'  => 'title_tagline',
+				'settings' => 'primer_author_credit',
+				'type'     => 'checkbox',
 			)
 		);
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -13,7 +13,7 @@ class Primer_Site_Identity_Options {
 	 */
 	public function __construct() {
 
-		add_filter( 'primer_author_credit', array( $this, 'toggle_footer_site_credits' ) );
+		add_filter( 'primer_author_credit', array( $this, 'toggle_primer_author_credit' ) );
 
 		add_action( 'customize_register', array( $this, 'customize_register' ) );
 
@@ -27,9 +27,9 @@ class Primer_Site_Identity_Options {
 	 *
 	 * @return boolean true|false based on site option
 	 */
-	public function toggle_footer_site_credits() {
+	public function toggle_primer_author_credit() {
 
-		if ( get_theme_mod( 'primer_footer_credits_visibility' ) ) {
+		if ( get_theme_mod( 'primer_author_credit' ) ) {
 
 			return true;
 
@@ -50,7 +50,7 @@ class Primer_Site_Identity_Options {
 	public function customize_register( WP_Customize_Manager $wp_customize ) {
 
 		$wp_customize->add_setting(
-			'primer_footer_credits_visibility',
+			'primer_author_credit',
 			array(
 				'default' => 1,
 			)
@@ -61,7 +61,7 @@ class Primer_Site_Identity_Options {
 			array(
 				'label'       => esc_html__( 'Display theme author credits', 'primer' ),
 				'section'     => 'title_tagline',
-				'settings'    => 'primer_footer_credits_visibility',
+				'settings'    => 'primer_author_credit',
 				'type'        => 'checkbox',
 			)
 		);

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -42,7 +42,9 @@ class Primer_Site_Identity_Options {
 	 */
 	public function toggle_primer_author_credit() {
 
-		return ! empty( get_theme_mod( 'show_author_credit' ) );
+		$show_author_credit = get_theme_mod( 'show_author_credit' );
+
+		return ! empty( $show_author_credit );
 
 	}
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -36,7 +36,7 @@ class Primer_Site_Identity_Options {
 	 * @action primer_author_credit
 	 * @since 1.4.2
 	 *
-	 * @return boolean true|false based on theme mod
+	 * @return bool
 	 */
 	public function toggle_primer_author_credit() {
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -35,7 +35,7 @@ class Primer_Site_Identity_Options {
 	/**
 	 * Toggle the visibility of the site credits in the footer.
 	 *
-	 * @action primer_author_credit
+	 * @filter primer_author_credit
 	 * @since  NEXT
 	 *
 	 * @return bool

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -35,13 +35,7 @@ class Primer_Site_Identity_Options {
 	 */
 	public function toggle_primer_author_credit() {
 
-		if ( get_theme_mod( 'primer_author_credit' ) ) {
-
-			return true;
-
-		}
-
-		return false;
+		return get_theme_mod( 'primer_author_credit' ) ? true : false;
 
 	}
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -13,6 +13,12 @@ class Primer_Site_Identity_Options {
 	 */
 	public function __construct() {
 
+		if ( class_exists( 'WPaaS\Log\Components\Plugin' ) && WPaaS\Plugin::is_reseller() ) {
+
+			return;
+
+		}
+
 		add_filter( 'primer_author_credit', array( $this, 'toggle_primer_author_credit' ) );
 
 		add_action( 'customize_register', array( $this, 'customize_register' ) );

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -14,9 +14,11 @@ class Primer_Site_Identity_Options {
 	public function __construct() {
 
 		/**
-		 * Disable additional site identity options
+		 * Filter the site identity settings display.
 		 *
 		 * @since NEXT
+		 *
+		 * @var bool
 		 */
 		if ( ! (bool) apply_filters( 'primer_show_site_identity_settings', true ) ) {
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Additional site identity customizer options.
+ *
+ * @package Primer
+ * @since   1.4.2
+ */
+
+class Primer_Site_Identity_Options {
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+
+		add_filter( 'primer_author_credit', array( $this, 'toggle_footer_site_credits' ) );
+
+		add_action( 'customize_register', array( $this, 'customize_register' ) );
+
+	}
+
+	/**
+	 * Toggle the visibility of the site credits in the footer.
+	 *
+	 * @action primer_author_credit
+	 * @since 1.4.2
+	 *
+	 * @return boolean true|false based on site option
+	 */
+	public function toggle_footer_site_credits() {
+
+		if ( get_theme_mod( 'primer_footer_credits_visibility' ) ) {
+
+			return true;
+
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Register additional site identity options.
+	 *
+	 * @action customize_register
+	 * @since  1.4.2
+	 *
+	 * @param WP_Customize_Manager $wp_customize
+	 */
+	public function customize_register( WP_Customize_Manager $wp_customize ) {
+
+		$wp_customize->add_setting(
+			'primer_footer_credits_visibility',
+			array(
+				'default' => 1,
+			)
+		);
+
+		$wp_customize->add_control(
+			'page_width',
+			array(
+				'label'       => esc_html__( 'Display theme author credits', 'primer' ),
+				'section'     => 'title_tagline',
+				'settings'    => 'primer_footer_credits_visibility',
+				'type'        => 'checkbox',
+			)
+		);
+
+	}
+
+}
+
+$GLOBALS['primer_site_identity_options'] = new Primer_Site_Identity_Options;

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -3,7 +3,7 @@
  * Additional site identity customizer options.
  *
  * @package Primer
- * @since   1.4.2
+ * @since   NEXT
  */
 
 class Primer_Site_Identity_Options {
@@ -16,7 +16,7 @@ class Primer_Site_Identity_Options {
 		/**
 		 * Disable additional site identity options
 		 *
-		 * @since 1.4.2
+		 * @since NEXT
 		 */
 		if ( ! (bool) apply_filters( 'primer_show_site_identity_settings', true ) ) {
 
@@ -34,7 +34,7 @@ class Primer_Site_Identity_Options {
 	 * Toggle the visibility of the site credits in the footer.
 	 *
 	 * @action primer_author_credit
-	 * @since 1.4.2
+	 * @since  NEXT
 	 *
 	 * @return bool
 	 */
@@ -48,7 +48,7 @@ class Primer_Site_Identity_Options {
 	 * Register additional site identity options.
 	 *
 	 * @action customize_register
-	 * @since  1.4.2
+	 * @since  NEXT
 	 *
 	 * @param WP_Customize_Manager $wp_customize
 	 */

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -42,7 +42,7 @@ class Primer_Site_Identity_Options {
 	 */
 	public function toggle_primer_author_credit() {
 
-		return get_theme_mod( 'show_author_credit' ) ? true : false;
+		return ! empty( get_theme_mod( 'show_author_credit' ) );
 
 	}
 


### PR DESCRIPTION
This PR adds an additional option to the 'Site Identity' panel, allowing users to toggle the visibility of the theme author credits displayed in the site footer. This allows users to remove the author credit without having to write custom code.

The theme mod is set to `1` (on) out of the box.

**Setting Toggled On (_default_)**
![Example Option - On](https://cldup.com/TfNDLzJWz2.png)

**Setting Toggled Off**
![Example Option - Off](https://cldup.com/c5ex_AFVLs.png)