### PR TITLE
Tweak footer credit

### DIFF
--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -31,10 +31,10 @@ if ( (bool) apply_filters( 'primer_author_credit', true ) ) {
 	$theme = wp_get_theme();
 
 	printf(
-		esc_html_x( '%1$s theme by %2$s', '1. theme name link, 2. theme author link', 'primer' ),
+		esc_html_x( '%1$s WordPress theme by %2$s', '1. theme name link, 2. theme author link', 'primer' ),
 		$theme->get( 'Name' ),
 		sprintf(
-			'<a href="%s" rel="author">%s</a>',
+			'<a href="%s" rel="author" rel="nofollow">%s</a>',
 			esc_url( $theme->get( 'AuthorURI' ) ),
 			esc_html( $theme->get( 'Author' ) )
 		)

--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -34,7 +34,7 @@ if ( (bool) apply_filters( 'primer_author_credit', true ) ) {
 		esc_html_x( '%1$s WordPress theme by %2$s', '1. theme name link, 2. theme author link', 'primer' ),
 		$theme->get( 'Name' ),
 		sprintf(
-			'<a href="%s" rel="author" rel="nofollow">%s</a>',
+			'<a href="%s" rel="author nofollow">%s</a>',
 			esc_url( $theme->get( 'AuthorURI' ) ),
 			esc_html( $theme->get( 'Author' ) )
 		)


### PR DESCRIPTION
@fjarrett Please review.

Appended "WordPress" after the theme name.
Added a `rel="nofollow"` onto the GoDaddy credit link.