### PR TITLE
Introduce copyright_text customizer setting

### DIFF
--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -45,7 +45,7 @@ class Primer_Site_Identity_Options {
 	 */
 	public function toggle_primer_author_credit() {
 
-		$show_author_credit = get_theme_mod( 'show_author_credit' );
+		$show_author_credit = get_theme_mod( 'show_author_credit', true );
 
 		return ! empty( $show_author_credit );
 
@@ -64,6 +64,30 @@ class Primer_Site_Identity_Options {
 	public function customize_register( WP_Customize_Manager $wp_customize ) {
 
 		$wp_customize->add_setting(
+			'copyright_text',
+			array(
+				'sanitize_callback' => 'wp_kses_post',
+				'default'           => sprintf(
+					esc_html_x( 'Copyright %1$s %2$d %3$s', '1. copyright symbol, 2. year, 3. site title', 'primer' ),
+					'&copy;',
+					date( 'Y' ),
+					get_bloginfo( 'blogname' )
+				),
+			)
+		);
+
+		$wp_customize->add_control(
+			'copyright_text',
+			array(
+				'label'    => esc_html__( 'Footer Copyright Text', 'primer' ),
+				'section'  => 'title_tagline',
+				'settings' => 'copyright_text',
+				'type'     => 'text',
+				'priority' => 40,
+			)
+		);
+
+		$wp_customize->add_setting(
 			'show_author_credit',
 			array(
 				'default'           => 1,
@@ -72,13 +96,13 @@ class Primer_Site_Identity_Options {
 		);
 
 		$wp_customize->add_control(
-			'page_width',
+			'show_author_credit',
 			array(
 				'label'    => esc_html__( 'Display theme author credit', 'primer' ),
 				'section'  => 'title_tagline',
 				'settings' => 'show_author_credit',
 				'type'     => 'checkbox',
-				'priority' => 40,
+				'priority' => 50,
 			)
 		);
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -66,8 +66,9 @@ class Primer_Site_Identity_Options {
 		$wp_customize->add_setting(
 			'copyright_text',
 			array(
-				'sanitize_callback' => 'wp_kses_post',
-				'default'           => sprintf(
+				'sanitize_callback'    => 'wp_kses_post',
+				'sanitize_js_callback' => 'wp_kses_post',
+				'default'              => sprintf(
 					esc_html_x( 'Copyright %1$s %2$d %3$s', '1. copyright symbol, 2. year, 3. site title', 'primer' ),
 					'&copy;',
 					date( 'Y' ),

--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -35,7 +35,7 @@ echo wp_kses_post( $copyright_text );
  */
 if ( (bool) apply_filters( 'primer_author_credit', true ) ) {
 
-	if ( ! empty( $copyright_text ) ) {
+	if ( $copyright_text ) {
 
 		echo ' &mdash; ';
 

--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -10,7 +10,14 @@
 <div class="site-info-text">
 <?php
 
-$copyright_text = apply_filters( 'primer_copyright_text', get_theme_mod( 'copyright_text', sprintf(
+/**
+ * Filter the footer copyright text.
+ *
+ * @since NEXT
+ *
+ * @var string
+ */
+$copyright_text = (string) apply_filters( 'primer_copyright_text', get_theme_mod( 'copyright_text', sprintf(
 	esc_html_x( 'Copyright %1$s %2$d %3$s', '1. copyright symbol, 2. year, 3. site title', 'primer' ),
 	'&copy;',
 	date( 'Y' ),

--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -10,12 +10,14 @@
 <div class="site-info-text">
 <?php
 
-printf(
+$copyright_text = apply_filters( 'primer_copyright_text', get_theme_mod( 'copyright_text', sprintf(
 	esc_html_x( 'Copyright %1$s %2$d %3$s', '1. copyright symbol, 2. year, 3. site title', 'primer' ),
 	'&copy;',
 	date( 'Y' ),
 	get_bloginfo( 'blogname' )
-);
+) ) );
+
+echo wp_kses_post( $copyright_text );
 
 /**
  * Filter the footer author credit display.
@@ -26,7 +28,12 @@ printf(
  */
 if ( (bool) apply_filters( 'primer_author_credit', true ) ) {
 
-	echo ' &mdash; ';
+
+	if ( ! empty( $copyright_text ) ) {
+
+		echo ' &mdash; ';
+
+	}
 
 	$theme = wp_get_theme();
 

--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -28,7 +28,6 @@ echo wp_kses_post( $copyright_text );
  */
 if ( (bool) apply_filters( 'primer_author_credit', true ) ) {
 
-
 	if ( ! empty( $copyright_text ) ) {
 
 		echo ' &mdash; ';


### PR DESCRIPTION
@fjarrett Please review.

Resolves #155 

This pull request introduces a new setting to allow customers to alter the copyright text in the footer.

![Example](https://cldup.com/d8EQxp5_Ut.png)

Additionally, when a customer excludes the footer copyright text the mdash is removed from the theme author credit text.

![No mdash](https://cldup.com/ubQr48HXvd.png)

One final adjustment was made to `toggle_primer_author_credit()` to set the default true. On a fresh install the theme author credit was not present on the front end of the site, but inside of the customizer the option was checked off.