### PR TITLE
Utilize core post navigation functions

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -163,42 +163,23 @@ function primer_paging_nav() {
  */
 function primer_post_nav() {
 
-	global $post;
+	/**
+	 * Filter the next/prev navigation text
+	 *
+	 * @since NEXT
+	 *
+	 * @var array
+	 */
+	$navigation_text = (array) apply_filters( 'primer_post_nav_text', [
+		'next_text' => '%title &rarr;',
+		'prev_text' => '&larr; %title',
+	] );
 
-	$previous = is_attachment() ? get_post( $post->post_parent ) : get_adjacent_post( false, '', true );
-	$next     = get_adjacent_post( false, '', false );
-
-	if ( ! $next && ! $previous ) {
-
-		return;
-
-	}
-
-	?>
-	<nav class="navigation post-navigation">
-
-		<h1 class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'primer' ); ?></h1>
-
-		<div class="nav-links">
-
-		<?php if ( is_rtl() ) : ?>
-
-			<div class="nav-next"><?php next_post_link( '%link &larr;' ); ?></div>
-
-			<div class="nav-previous"><?php previous_post_link( '&rarr; %link' ); ?></div>
-
-		<?php else : ?>
-
-			<div class="nav-previous"><?php previous_post_link( '&larr; %link' ); ?></div>
-
-			<div class="nav-next"><?php next_post_link( '%link &rarr;' ); ?></div>
-
-		<?php endif; ?>
-
-		</div><!-- .nav-links -->
-
-	</nav><!-- .navigation -->
-	<?php
+	echo wp_kses_post( get_the_post_navigation( array(
+		'next_text' => "<div class='nav-next'>{$navigation_text['next_text']}</div>",
+		'prev_text' => "<div class='nav-previous'>{$navigation_text['prev_text']}</div>",
+		'screen_reader_text' => esc_html__( 'Post navigation', 'primer' ),
+	) ) );
 
 }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -166,20 +166,26 @@ function primer_paging_nav() {
 function primer_post_nav() {
 
 	/**
-	 * Filter the next/prev navigation text
+	 * Filter the next post navigation label
 	 *
 	 * @since NEXT
 	 *
-	 * @var array
+	 * @var string
 	 */
-	$navigation_text = (array) apply_filters( 'primer_post_nav_text', [
-		'next_text' => '%title &rarr;',
-		'prev_text' => '&larr; %title',
-	] );
+	$next_label = (string) apply_filters( 'primer_post_nav_label_next', '%title &rarr;' );
+
+	/**
+	 * Filter the prev post navigation label
+	 *
+	 * @since NEXT
+	 *
+	 * @var string
+	 */
+	$prev_label = (string) apply_filters( 'primer_post_nav_label_prev', '&larr; %title' );
 
 	the_post_navigation( array(
-		'next_text'          => "<div class='nav-next'>{$navigation_text['next_text']}</div>",
-		'prev_text'          => "<div class='nav-previous'>{$navigation_text['prev_text']}</div>",
+		'next_text'          => "<div class='nav-next'>{$next_label}</div>",
+		'prev_text'          => "<div class='nav-previous'>{$prev_label}</div>",
 		'screen_reader_text' => esc_html__( 'Post navigation', 'primer' ),
 	) );
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,7 +158,7 @@ function primer_paging_nav() {
 /**
  * Display navigation to next/previous post when applicable.
  *
- * @uses get_the_post_navigation
+ * @uses the_post_navigation
  * @uses primer_post_nav_text
  *
  * @since  1.0.0
@@ -177,11 +177,11 @@ function primer_post_nav() {
 		'prev_text' => '&larr; %title',
 	] );
 
-	echo wp_kses_post( get_the_post_navigation( array(
-		'next_text' => "<div class='nav-next'>{$navigation_text['next_text']}</div>",
-		'prev_text' => "<div class='nav-previous'>{$navigation_text['prev_text']}</div>",
+	the_post_navigation( array(
+		'next_text'          => "<div class='nav-next'>{$navigation_text['next_text']}</div>",
+		'prev_text'          => "<div class='nav-previous'>{$navigation_text['prev_text']}</div>",
 		'screen_reader_text' => esc_html__( 'Post navigation', 'primer' ),
-	) ) );
+	) );
 
 }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,7 +158,9 @@ function primer_paging_nav() {
 /**
  * Display navigation to next/previous post when applicable.
  *
- * @global WP_Post $post
+ * @uses get_the_post_navigation
+ * @uses primer_post_nav_text
+ *
  * @since  1.0.0
  */
 function primer_post_nav() {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -156,38 +156,30 @@ function primer_paging_nav() {
 }
 
 /**
- * Display navigation to next/previous post when applicable.
+ * Display navigation to next/previous post, when applicable.
  *
- * @uses the_post_navigation
- * @uses primer_post_nav_text
+ * @since 1.0.0
+ * @uses  the_post_navigation
  *
- * @since  1.0.0
+ * @param array $args (optional)
  */
-function primer_post_nav() {
+function primer_post_nav( $args = array() ) {
 
 	/**
-	 * Filter the next post navigation label
+	 * Filter the default post navigation args.
 	 *
 	 * @since NEXT
 	 *
-	 * @var string
+	 * @var array
 	 */
-	$next_label = (string) apply_filters( 'primer_post_nav_label_next', '%title &rarr;' );
-
-	/**
-	 * Filter the prev post navigation label
-	 *
-	 * @since NEXT
-	 *
-	 * @var string
-	 */
-	$prev_label = (string) apply_filters( 'primer_post_nav_label_prev', '&larr; %title' );
-
-	the_post_navigation( array(
-		'next_text'          => "<div class='nav-next'>{$next_label}</div>",
-		'prev_text'          => "<div class='nav-previous'>{$prev_label}</div>",
-		'screen_reader_text' => esc_html__( 'Post navigation', 'primer' ),
+	$defaults = (array) apply_filters( 'primer_post_nav_default_args', array(
+		'prev_text' => '&larr; %title',
+		'next_text' => '%title &rarr;',
 	) );
+
+	$args = wp_parse_args( $args, $defaults );
+
+	the_post_navigation( $args );
 
 }
 


### PR DESCRIPTION
Resolves #127 

This pull request also introduces a new filter `primer_post_nav_text`, which allows users to customize the next/prev post navigation text.

I think we can get this in the **1.5.0** release.