### PR TITLE
Fix all occurences of _x

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -31,8 +31,8 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 		<?php
 
-		/* translators: 1. number of comments, 2. post title */
 		printf( // xss ok.
+			/* translators: 1. number of comments, 2. post title */
 			_n(
 				'%1$d thought on %2$s',
 				'%1$d thoughts on %2$s',
@@ -55,9 +55,9 @@ if ( post_password_required() ) {
 
 				<h1 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'primer' ); ?></h1>
 
-				<div class="nav-previous"><?php /* translators: left arrow (LTR) / right arrow (RTL) */ previous_comments_link( sprintf( esc_html__( '%s Older Comments', 'primer' ), is_rtl() ? '&rarr;' : '&larr;' ) ); ?></div>
+				<div class="nav-previous"><?php previous_comments_link( sprintf( /* translators: left arrow (LTR) / right arrow (RTL) */ esc_html__( '%s Older Comments', 'primer' ), is_rtl() ? '&rarr;' : '&larr;' ) ); ?></div>
 
-				<div class="nav-next"><?php /* translators: right arrow (LTR) / left arrow (RTL) */ next_comments_link( sprintf( esc_html__( 'Newer Comments %s', 'primer' ), is_rtl() ? '&larr;' : '&rarr;' ) ); ?></div>
+				<div class="nav-next"><?php next_comments_link( sprintf( /* translators: right arrow (LTR) / left arrow (RTL) */ esc_html__( 'Newer Comments %s', 'primer' ), is_rtl() ? '&larr;' : '&rarr;' ) ); ?></div>
 
 			</nav><!-- #comment-nav-above -->
 

--- a/comments.php
+++ b/comments.php
@@ -31,12 +31,12 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 		<?php
 
+		/* translators: 1. number of comments, 2. post title */
 		printf( // xss ok.
-			_nx(
+			_n(
 				'%1$d thought on %2$s',
 				'%1$d thoughts on %2$s',
 				get_comments_number(),
-				'1. number of comments, 2. post title',
 				'primer'
 			),
 			number_format_i18n( get_comments_number() ),
@@ -55,9 +55,9 @@ if ( post_password_required() ) {
 
 				<h1 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'primer' ); ?></h1>
 
-				<div class="nav-previous"><?php previous_comments_link( sprintf( esc_html_x( '%s Older Comments', 'left arrow (LTR) / right arrow (RTL)', 'primer' ), is_rtl() ? '&rarr;' : '&larr;' ) ); ?></div>
+				<div class="nav-previous"><?php /* translators: left arrow (LTR) / right arrow (RTL) */ previous_comments_link( sprintf( esc_html__( '%s Older Comments', 'primer' ), is_rtl() ? '&rarr;' : '&larr;' ) ); ?></div>
 
-				<div class="nav-next"><?php next_comments_link( sprintf( esc_html_x( 'Newer Comments %s', 'right arrow (LTR) / left arrow (RTL)', 'primer' ), is_rtl() ? '&larr;' : '&rarr;' ) ); ?></div>
+				<div class="nav-next"><?php /* translators: right arrow (LTR) / left arrow (RTL) */ next_comments_link( sprintf( esc_html__( 'Newer Comments %s', 'primer' ), is_rtl() ? '&larr;' : '&rarr;' ) ); ?></div>
 
 			</nav><!-- #comment-nav-above -->
 

--- a/content-none.php
+++ b/content-none.php
@@ -25,8 +25,8 @@
 			<p>
 			<?php
 
-			/* translators: link to write a new post */
 			printf(
+				/* translators: link to write a new post */
 				esc_html__( 'Ready to publish your first post? %s.', 'primer' ),
 				sprintf(
 					'<a href="%s">%s</a>',

--- a/content-none.php
+++ b/content-none.php
@@ -25,8 +25,9 @@
 			<p>
 			<?php
 
+			/* translators: link to write a new post */
 			printf(
-				esc_html_x( 'Ready to publish your first post? %s.', 'link to write a new post', 'primer' ),
+				esc_html__( 'Ready to publish your first post? %s.', 'primer' ),
 				sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( admin_url( 'post-new.php' ) ),

--- a/inc/compat/deprecated.php
+++ b/inc/compat/deprecated.php
@@ -114,8 +114,8 @@ function primer_deprecated( $name, $version, $alt_name = null, $theme = null, $m
 	}
 
 	// Note: Translation text must be a string or the themecheck will flag it.
-	$with_alt    = function_exists( '_x' ) ? _x( '%1$s is <strong>deprecated</strong> since %2$s version %3$s! Use %4$s instead.', '1. PHP function name, 2. theme name, 3. version number, 4. alternative function name', 'primer' ) : '%1$s is <strong>deprecated</strong> since %2$s version %3$s! Use %4$s instead.';
-	$without_alt = function_exists( '_x' ) ? _x( '%1$s is <strong>deprecated</strong> since %2$s version %3$s with no alternative available.', '1. PHP function name, 2. theme name, 3. version number', 'primer' ) : '%1$s is <strong>deprecated</strong> since %2$s version %3$s with no alternative available.';
+	$with_alt    = function_exists( '__' ) ? /* translators: 1. PHP function name, 2. theme name, 3. version number, 4. alternative function name */ __( '%1$s is <strong>deprecated</strong> since %2$s version %3$s! Use %4$s instead.', 'primer' ) : '%1$s is <strong>deprecated</strong> since %2$s version %3$s! Use %4$s instead.';
+	$without_alt = function_exists( '__' ) ? /* translators: 1. PHP function name, 2. theme name, 3. version number */ __( '%1$s is <strong>deprecated</strong> since %2$s version %3$s with no alternative available.', 'primer' ) : '%1$s is <strong>deprecated</strong> since %2$s version %3$s with no alternative available.';
 
 	$string  = ( $alt_name ) ? $with_alt : $without_alt;
 	$theme   = ! empty( $theme ) ? $theme : esc_html__( 'Primer', 'primer' );

--- a/inc/customizer/colors.php
+++ b/inc/customizer/colors.php
@@ -479,47 +479,47 @@ class Primer_Customizer_Colors {
 
 		$color_schemes = array(
 			'blush' => array(
-				'label' => esc_html_x( 'Blush', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Blush', 'primer' ),
 				'base'  => '#cc494f',
 			),
 			'bronze' => array(
-				'label' => esc_html_x( 'Bronze', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Bronze', 'primer' ),
 				'base'  => '#b1a18b',
 			),
 			'canary' => array(
-				'label' => esc_html_x( 'Canary', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Canary', 'primer' ),
 				'base'  => '#e9c46a',
 			),
 			'cool' => array(
-				'label' => esc_html_x( 'Cool', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Cool', 'primer' ),
 				'base'  => '#78c3fb',
 			),
 			'dark' => array(
-				'label' => esc_html_x( 'Dark', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Dark', 'primer' ),
 				'base'  => '#222222',
 			),
 			'iguana' => array(
-				'label' => esc_html_x( 'Iguana', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Iguana', 'primer' ),
 				'base'  => '#62bf7c',
 			),
 			'muted' => array(
-				'label' => esc_html_x( 'Muted', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Muted', 'primer' ),
 				'base'  => '#3e4c75',
 			),
 			'plum' => array(
-				'label' => esc_html_x( 'Plum', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Plum', 'primer' ),
 				'base'  => '#5d5179',
 			),
 			'rose' => array(
-				'label' => esc_html_x( 'Rose', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Rose', 'primer' ),
 				'base'  => '#f49390',
 			),
 			'tangerine' => array(
-				'label' => esc_html_x( 'Tangerine', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Tangerine', 'primer' ),
 				'base'  => '#fc9e4f',
 			),
 			'turquoise' => array(
-				'label' => esc_html_x( 'Turquoise', 'color scheme name', 'primer' ),
+				'label' => /* translators: color scheme name */ esc_html__( 'Turquoise', 'primer' ),
 				'base'  => '#48e5c2',
 			),
 		);

--- a/inc/customizer/fonts.php
+++ b/inc/customizer/fonts.php
@@ -214,7 +214,7 @@ class Primer_Customizer_Fonts {
 
 			$fonts             = array_combine( $this->fonts, $this->fonts );
 			$default           = $this->get_default_font( $name );
-			$fonts[ $default ] = sprintf( esc_html_x( '%s (Default)', 'font name', 'primer' ), $default );
+			$fonts[ $default ] = /* translators: font name */ sprintf( esc_html__( '%s (Default)', 'primer' ), $default );
 
 			$wp_customize->add_control(
 				$name,

--- a/inc/customizer/fonts.php
+++ b/inc/customizer/fonts.php
@@ -214,7 +214,7 @@ class Primer_Customizer_Fonts {
 
 			$fonts             = array_combine( $this->fonts, $this->fonts );
 			$default           = $this->get_default_font( $name );
-			$fonts[ $default ] = /* translators: font name */ sprintf( esc_html__( '%s (Default)', 'primer' ), $default );
+			$fonts[ $default ] = sprintf( /* translators: font name */ esc_html__( '%s (Default)', 'primer' ), $default );
 
 			$wp_customize->add_control(
 				$name,

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -96,8 +96,8 @@ class Primer_Customizer_Layouts {
 		 */
 		$this->page_widths = (array) apply_filters( 'primer_page_widths',
 			array(
-				'fixed' => esc_html_x( 'Fixed', 'fixed-width page layout', 'primer' ),
-				'fluid' => esc_html_x( 'Fluid', 'fluid-width page layout', 'primer' ),
+				'fixed' => /* translators: fixed-width page layout */ esc_html__( 'Fixed', 'primer' ),
+				'fluid' => /* translators: fluid-width page layout */ esc_html__( 'Fluid', 'primer' ),
 			)
 		);
 

--- a/inc/customizer/site-identity.php
+++ b/inc/customizer/site-identity.php
@@ -68,7 +68,8 @@ class Primer_Site_Identity_Options {
 				'sanitize_callback'    => 'wp_kses_post',
 				'sanitize_js_callback' => 'wp_kses_post',
 				'default'              => sprintf(
-					esc_html_x( 'Copyright %1$s %2$d %3$s', '1. copyright symbol, 2. year, 3. site title', 'primer' ),
+					/* translators: 1. copyright symbol, 2. year, 3. site title */
+					esc_html__( 'Copyright %1$s %2$d %3$s', 'primer' ),
 					'&copy;',
 					date( 'Y' ),
 					get_bloginfo( 'blogname' )

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -42,7 +42,8 @@ function primer_get_the_page_title() {
 		case is_search() :
 
 			$title = sprintf(
-				esc_html_x( 'Search Results for: %s', 'search term', 'primer' ),
+				/* translators: search term */
+				esc_html__( 'Search Results for: %s', 'primer' ),
 				sprintf(
 					'<span>%s</span>',
 					get_search_query()

--- a/inc/hero-text-widget.php
+++ b/inc/hero-text-widget.php
@@ -21,12 +21,13 @@ class Primer_Hero_Text_Widget extends WP_Widget {
 			'customize_selective_refresh' => true,
 			'classname'                   => 'widget_text primer-widgets primer-hero-text-widget',
 			'description'                 => sprintf(
-				esc_html_x( "A %s theme widget designed for the Hero area on your site's front page.", 'theme name', 'primer' ),
+				/* translators: theme name */
+				esc_html__( "A %s theme widget designed for the Hero area on your site's front page.", 'primer' ),
 				esc_html( $this->get_current_theme_name() )
 			),
 		);
 
-		parent::__construct( 'primer-hero-text', esc_html_x( 'Hero Text', 'the widget title', 'primer' ), $widget_options );
+		parent::__construct( 'primer-hero-text', /* translators: the widget title */ esc_html__( 'Hero Text', 'primer' ), $widget_options );
 
 		add_action( 'admin_init', array( $this, 'register_scripts' ) );
 

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -410,7 +410,8 @@ function primer_wp_title( $title, $sep ) {
 			' %s %s',
 			$sep,
 			sprintf(
-				esc_html_x( 'Page %d', 'page number', 'primer' ),
+				/* translators: page number */
+				esc_html__( 'Page %d', 'primer' ),
 				max( $paged, $page )
 			)
 		);
@@ -447,7 +448,8 @@ function primer_pagination_template( $template, $class ) {
 	$replace = sprintf(
 		'<div class="paging-nav-text">%s</div>%s',
 		sprintf(
-			esc_html_x( 'Page %1$d of %2$d', '1. current page number, 2. total number of pages', 'primer' ),
+			/* translators: 1. current page number, 2. total number of pages */
+			esc_html__( 'Page %1$d of %2$d', 'primer' ),
 			max( 1, get_query_var( 'paged' ) ),
 			absint( $wp_query->max_num_pages )
 		),

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -150,7 +150,7 @@ function primer_pagination( $args = array() ) {
 	$defaults = (array) apply_filters( 'primer_pagination_default_args', array(
 		'prev_text'          => __( '&larr; Previous', 'primer' ),
 		'next_text'          => __( 'Next &rarr;', 'primer' ),
-		'screen_reader_text' => sprintf( esc_html_x( '%1$s navigation', 'post type singular label', 'primer' ), esc_html( $post_type_label ) ),
+		'screen_reader_text' => sprintf( /* translators: post type singular label */ esc_html__( '%1$s navigation', 'primer' ), esc_html( $post_type_label ) ),
 	), max( 1, get_query_var( 'paged' ) ), absint( $wp_query->max_num_pages ) );
 
 	$args = wp_parse_args( $args, $defaults );

--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -20,7 +20,8 @@
 	 * @var string
 	 */
 	$copyright_text = (string) apply_filters( 'primer_copyright_text', get_theme_mod( 'copyright_text', sprintf(
-		esc_html_x( 'Copyright %1$s %2$d %3$s', '1. copyright symbol, 2. year, 3. site title', 'primer' ),
+		/* translators: 1. copyright symbol, 2. year, 3. site title */
+		esc_html__( 'Copyright %1$s %2$d %3$s', 'primer' ),
 		'&copy;',
 		date( 'Y' ),
 		get_bloginfo( 'blogname' )
@@ -46,7 +47,8 @@
 		$theme = wp_get_theme();
 
 		printf(
-			esc_html_x( '%1$s WordPress theme by %2$s', '1. theme name link, 2. theme author link', 'primer' ),
+			/* translators: 1. theme name link, 2. theme author link */
+			esc_html__( '%1$s WordPress theme by %2$s', 'primer' ),
 			esc_html( $theme->get( 'Name' ) ),
 			sprintf(
 				'<a href="%s" rel="author nofollow">%s</a>',

--- a/templates/parts/loop/post-excerpt.php
+++ b/templates/parts/loop/post-excerpt.php
@@ -12,6 +12,6 @@
 
 	<?php the_excerpt(); ?>
 
-	<p><a class="button" href="<?php the_permalink(); ?>"><?php printf( esc_html_x( 'Continue Reading %s', 'right arrow (LTR) / left arrow (RTL)', 'primer' ), is_rtl() ? '&larr;' : '&rarr;' ); ?></a></p>
+	<p><a class="button" href="<?php the_permalink(); ?>"><?php printf( /* translators: right arrow (LTR) / left arrow (RTL) */ esc_html__( 'Continue Reading %s', 'primer' ), is_rtl() ? '&larr;' : '&rarr;' ); ?></a></p>
 
 </div><!-- .entry-summary -->

--- a/templates/parts/loop/post-footer.php
+++ b/templates/parts/loop/post-footer.php
@@ -18,25 +18,25 @@
 
 	<?php if ( 'post' === get_post_type() ) : ?>
 
-		<?php $category_list = get_the_category_list( esc_html_x( ', ', 'separator for items in a list', 'primer' ) ); ?>
+		<?php $category_list = get_the_category_list( /* translators: separator for items in a list */ esc_html__( ', ', 'primer' ) ); ?>
 
 		<?php if ( $category_list && primer_has_active_categories() ) : ?>
 
 			<span class="cat-links">
 
-				<?php printf( esc_html_x( 'Posted in: %s', 'category list', 'primer' ), $category_list ); // xss ok. ?>
+				<?php printf( /* translators: category list */ esc_html__( 'Posted in: %s', 'primer' ), $category_list ); // xss ok. ?>
 
 			</span>
 
 		<?php endif; ?>
 
-		<?php $tag_list = get_the_tag_list( '', esc_html_x( ', ', 'separator for items in a list', 'primer' ) ); ?>
+		<?php $tag_list = get_the_tag_list( '', /* translators: separator for items in a list */ esc_html__( ', ', 'primer' ) ); ?>
 
 		<?php if ( $tag_list ) : ?>
 
 			<span class="tags-links">
 
-				<?php printf( esc_html_x( 'Filed under: %s', 'tag list', 'primer' ), $tag_list ); // xss ok. ?>
+				<?php printf( /* translators: tag list */ esc_html__( 'Filed under: %s', 'primer' ), $tag_list ); // xss ok. ?>
 
 			</span>
 

--- a/templates/parts/loop/post-meta.php
+++ b/templates/parts/loop/post-meta.php
@@ -22,7 +22,7 @@
 
 		<span class="comments-number">
 
-			<?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), esc_html_x( '% Comments', 'number of comments', 'primer' ), 'comments-link' ); ?>
+			<?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), /* translators: number of comments */ esc_html__( '%s Comments', 'primer' ), 'comments-link' ); ?>
 
 		</span>
 

--- a/templates/parts/loop/post-meta.php
+++ b/templates/parts/loop/post-meta.php
@@ -22,7 +22,7 @@
 
 		<span class="comments-number">
 
-			<?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), /* translators: number of comments */ esc_html__( '%s Comments', 'primer' ), 'comments-link' ); ?>
+			<?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), /* translators: number of comments */ esc_html__( '%d Comments', 'primer' ), 'comments-link' ); ?>
 
 		</span>
 

--- a/templates/parts/loop/post-search-footer.php
+++ b/templates/parts/loop/post-search-footer.php
@@ -40,7 +40,7 @@
 
 	<?php if ( ! post_password_required() && ( comments_open() || get_comments_number() ) ) : ?>
 
-		<span class="comments-link"><?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), /* translators: number of comments */ esc_html__( '%s Comments', 'primer' ) ); ?></span>
+		<span class="comments-link"><?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), /* translators: number of comments */ esc_html__( '%d Comments', 'primer' ) ); ?></span>
 
 	<?php endif; ?>
 

--- a/templates/parts/loop/post-search-footer.php
+++ b/templates/parts/loop/post-search-footer.php
@@ -12,25 +12,25 @@
 
 	<?php if ( 'post' === get_post_type() ) : ?>
 
-		<?php $category_list = get_the_category_list( esc_html_x( ', ', 'separator for items in a list', 'primer' ) ); ?>
+		<?php $category_list = get_the_category_list( /* translators: separator for items in a list */ esc_html__( ', ', 'primer' ) ); ?>
 
 		<?php if ( $category_list && primer_has_active_categories() ) : ?>
 
 			<span class="cat-links">
 
-				<?php printf( esc_html_x( 'Posted in: %s', 'category list', 'primer' ), $category_list ); // xss ok. ?>
+				<?php printf( /* translators: category list */ esc_html__( 'Posted in: %s', 'primer' ), $category_list ); // xss ok. ?>
 
 			</span>
 
 		<?php endif; ?>
 
-		<?php $tag_list = get_the_tag_list( '', esc_html_x( ', ', 'separator for items in a list', 'primer' ) ); ?>
+		<?php $tag_list = get_the_tag_list( '', /* translators: separator for items in a list */ esc_html__( ', ', 'primer' ) ); ?>
 
 		<?php if ( $tag_list ) : ?>
 
 			<span class="tags-links">
 
-				<?php printf( esc_html_x( 'Filed under: %s', 'tag list', 'primer' ), $tag_list ); // xss ok. ?>
+				<?php printf( /* translators: tag list */ esc_html__( 'Filed under: %s', 'primer' ), $tag_list ); // xss ok. ?>
 
 			</span>
 
@@ -40,7 +40,7 @@
 
 	<?php if ( ! post_password_required() && ( comments_open() || get_comments_number() ) ) : ?>
 
-		<span class="comments-link"><?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), esc_html_x( '% Comments', 'number of comments', 'primer' ) ); ?></span>
+		<span class="comments-link"><?php comments_popup_link( esc_html__( 'Leave a comment', 'primer' ), esc_html__( '1 Comment', 'primer' ), /* translators: number of comments */ esc_html__( '%s Comments', 'primer' ) ); ?></span>
 
 	<?php endif; ?>
 

--- a/templates/woocommerce/loop/pagination.php
+++ b/templates/woocommerce/loop/pagination.php
@@ -40,9 +40,9 @@ $post_type_label  = isset( $post_type_labels->singular_name ) ? $post_type_label
 
 <nav class="navigation pagination woocommerce-pagination">
 
-	<h2 class="screen-reader-text"><?php printf( esc_html_x( '%s navigation', 'post type singular label', 'primer' ), esc_html( $post_type_label ) ); ?></h2>
+	<h2 class="screen-reader-text"><?php printf( /* translators: post type singular label */ esc_html__( '%s navigation', 'primer' ), esc_html( $post_type_label ) ); ?></h2>
 
-	<div class="paging-nav-text"><?php printf( esc_html_x( 'Page %1$d of %2$d', '1. current page number, 2. total number of pages', 'primer' ), max( 1, get_query_var( 'paged' ) ), absint( $wp_query->max_num_pages ) ); // xss ok. ?></div>
+	<div class="paging-nav-text"><?php printf( /* translators: 1. current page number, 2. total number of pages */ esc_html__( 'Page %1$d of %2$d', 'primer' ), max( 1, get_query_var( 'paged' ) ), absint( $wp_query->max_num_pages ) ); // xss ok. ?></div>
 
 	<div class="nav-links">
 


### PR DESCRIPTION
Resolves #185 

Fix all occurrences of `_x` functions with proper `__()`/`_e()` function and  appropriate translator comments.

Example (Before):
```php
esc_html_x( 'Blush', 'color scheme name', 'primer' ),
```

Example (After):
```php
/* translators: color scheme name */
esc_html__( 'Blush', 'primer' )
```