### PR TITLE
Disable Woocommerce product image in header

### DIFF
--- a/inc/compat/woocommerce.php
+++ b/inc/compat/woocommerce.php
@@ -694,7 +694,7 @@ if ( ! function_exists( 'primer_wc_best_selling_products' ) ) {
 }
 
 /**
- * Prevent Woocommerce product image from loading in the header image
+ * Prevent WooCommerce product image from loading in the header image
  *
  * @return boolean False if a WooCommerce product, else true
  *
@@ -703,9 +703,7 @@ if ( ! function_exists( 'primer_wc_best_selling_products' ) ) {
 function disable_woo_product_header_image() {
 
 	/**
-	 * Filter whether the Woocommerce product should be used as the header image
-	 *
-	 * Default: false
+	 * Filter whether the WooCommerce product should be used as the header image
 	 *
 	 * @since NEXT
 	 *

--- a/inc/compat/woocommerce.php
+++ b/inc/compat/woocommerce.php
@@ -694,7 +694,7 @@ if ( ! function_exists( 'primer_wc_best_selling_products' ) ) {
 }
 
 /**
- * Prevent WooCommerce product image from loading in the header image
+ * Prevent WooCommerce product image from loading as the header image
  *
  * @return boolean False if a WooCommerce product, else true
  *

--- a/inc/compat/woocommerce.php
+++ b/inc/compat/woocommerce.php
@@ -706,8 +706,6 @@ function primer_wc_product_header_image() {
 	 * Filter whether the WooCommerce product should be used as the header image
 	 *
 	 * @since NEXT
-	 *
-	 * @return boolean False when WooCommerce product, else true
 	 */
 	return apply_filters( 'primer_wc_product_header_image', ! is_product() );
 

--- a/inc/compat/woocommerce.php
+++ b/inc/compat/woocommerce.php
@@ -700,7 +700,7 @@ if ( ! function_exists( 'primer_wc_best_selling_products' ) ) {
  *
  * @since NEXT
  */
-function disable_woo_product_header_image() {
+function primer_wc_product_header_image() {
 
 	/**
 	 * Filter whether the WooCommerce product should be used as the header image
@@ -712,4 +712,4 @@ function disable_woo_product_header_image() {
 	return apply_filters( 'primer_wc_product_header_image', ! is_product() );
 
 }
-add_filter( 'primer_use_featured_hero_image', 'disable_woo_product_header_image' );
+add_filter( 'primer_use_featured_hero_image', 'primer_wc_product_header_image' );

--- a/inc/compat/woocommerce.php
+++ b/inc/compat/woocommerce.php
@@ -707,7 +707,7 @@ function primer_wc_product_header_image() {
 	 *
 	 * @since NEXT
 	 *
-	 * @var boolean
+	 * @return boolean False when WooCommerce product, else true
 	 */
 	return apply_filters( 'primer_wc_product_header_image', ! is_product() );
 

--- a/inc/compat/woocommerce.php
+++ b/inc/compat/woocommerce.php
@@ -692,3 +692,26 @@ if ( ! function_exists( 'primer_wc_best_selling_products' ) ) {
 	}
 
 }
+
+/**
+ * Prevent Woocommerce product image from loading in the header image
+ *
+ * @return boolean False if a WooCommerce product, else true
+ *
+ * @since NEXT
+ */
+function disable_woo_product_header_image() {
+
+	/**
+	 * Filter whether the Woocommerce product should be used as the header image
+	 *
+	 * Default: false
+	 *
+	 * @since NEXT
+	 *
+	 * @var boolean
+	 */
+	return apply_filters( 'primer_wc_product_header_image', ! is_product() );
+
+}
+add_filter( 'primer_use_featured_hero_image', 'disable_woo_product_header_image' );


### PR DESCRIPTION
On single product pages the WooCommerce product image was hijacking the header image, which doesn't feel right.

Before:
![Example](https://cldup.com/-qzbd-SaAT.png)

After:
![After](https://cldup.com/6RnQ4N8FTG.png)