### PR TITLE
Fix tertiary sidebar visibility

### DIFF
--- a/sidebar-tertiary.php
+++ b/sidebar-tertiary.php
@@ -8,7 +8,7 @@
  * @since   1.0.0
  */
 
-if ( ! primer_layout_has_sidebar() || ! is_active_sidebar( 'sidebar-2' ) || 0 === strpos( primer_get_layout(), 'three-column-' ) ) {
+if ( ! primer_layout_has_sidebar() || ! is_active_sidebar( 'sidebar-2' ) || is_bool( strpos( primer_get_layout(), 'three-column' ) ) ) {
 
 	return;
 

--- a/sidebar-tertiary.php
+++ b/sidebar-tertiary.php
@@ -8,7 +8,7 @@
  * @since   1.0.0
  */
 
-if ( ! primer_layout_has_sidebar() || ! is_active_sidebar( 'sidebar-2' ) || is_bool( strpos( primer_get_layout(), 'three-column' ) ) ) {
+if ( ! primer_layout_has_sidebar() || ! is_active_sidebar( 'sidebar-2' ) || 0 !== strpos( primer_get_layout(), 'three-column' ) ) {
 
 	return;
 


### PR DESCRIPTION
Resolves #197

When a user selected any of the page templates with a secondary sidebar these weren't visible. (See #197 for screenshots).

The main issue was that we were checking `strpos` of 'three-columns' in the return of `primer_get_layout()`. Well when a three-column layout was selected, the position of the string was always 0, so the sidebar was never visible.

##### Example (Template: three-column-center)

```php
0 === strpos( primer_get_layout(), 'three-column-' )
```

☝️ Always returned 0 when the string was found. If the string was not found then a value of `FALSE` was returned.


##### Solution
The solution was to check if the returned value was a boolean or not.

```php
is_bool( strpos( primer_get_layout(), 'three-column' ) )
```

Inside of [sidebar-tertiary.php](https://github.com/godaddy/wp-primer-theme/blob/5d4070b8087469dc19057731b463b29f37763379/sidebar-tertiary.php#L11)

```php
if ( ! primer_layout_has_sidebar() || ! is_active_sidebar( 'sidebar-2' ) || is_bool( strpos( primer_get_layout(), 'three-column' ) ) ) {

	return;

}
```