### PR TITLE
Only load video header functionality when using WordPress 4.7 or higher

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -443,7 +443,14 @@ function primer_register_sidebars() {
 
 	foreach ( $sidebars as $id => $args ) {
 
-		register_sidebar( array_merge( array( 'id' => $id ), $args ) );
+		register_sidebar(
+			array_merge(
+				array(
+					'id' => $id,
+				),
+				$args
+			)
+		);
 
 	}
 
@@ -481,7 +488,7 @@ function primer_scripts() {
 
 	wp_style_add_data( $stylesheet, 'rtl', 'replace' );
 
-	$nav_dependencies = ( is_front_page() && has_header_video() ) ? array( 'jquery', 'wp-custom-header' ) : array( 'jquery' );
+	$nav_dependencies = ( is_front_page() && ( function_exists( 'has_header_video' ) && has_header_video() ) ) ? array( 'jquery', 'wp-custom-header' ) : array( 'jquery' );
 
 	wp_enqueue_script( 'primer-navigation', get_template_directory_uri() . "/assets/js/navigation{$suffix}.js", $nav_dependencies, PRIMER_VERSION, true );
 	wp_enqueue_script( 'primer-skip-link-focus-fix', get_template_directory_uri() . "/assets/js/skip-link-focus-fix{$suffix}.js", array(), PRIMER_VERSION, true );

--- a/functions.php
+++ b/functions.php
@@ -488,7 +488,7 @@ function primer_scripts() {
 
 	wp_style_add_data( $stylesheet, 'rtl', 'replace' );
 
-	$nav_dependencies = ( is_front_page() && ( function_exists( 'has_header_video' ) && has_header_video() ) ) ? array( 'jquery', 'wp-custom-header' ) : array( 'jquery' );
+	$nav_dependencies = ( is_front_page() && function_exists( 'has_header_video' ) && has_header_video() ) ? array( 'jquery', 'wp-custom-header' ) : array( 'jquery' );
 
 	wp_enqueue_script( 'primer-navigation', get_template_directory_uri() . "/assets/js/navigation{$suffix}.js", $nav_dependencies, PRIMER_VERSION, true );
 	wp_enqueue_script( 'primer-skip-link-focus-fix', get_template_directory_uri() . "/assets/js/skip-link-focus-fix{$suffix}.js", array(), PRIMER_VERSION, true );

--- a/functions.php
+++ b/functions.php
@@ -443,14 +443,7 @@ function primer_register_sidebars() {
 
 	foreach ( $sidebars as $id => $args ) {
 
-		register_sidebar(
-			array_merge(
-				array(
-					'id' => $id,
-				),
-				$args
-			)
-		);
+		register_sidebar( array_merge( array( 'id' => $id ), $args ) );
 
 	}
 

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -39,7 +39,7 @@ add_action( 'template_redirect', 'primer_elements' );
  */
 function primer_video_header() {
 
-	if ( ! is_front_page() || ! has_header_video() ) {
+	if ( ! is_front_page() || ! function_exists( 'has_header_video' ) || ! has_header_video() ) {
 
 		return;
 


### PR DESCRIPTION
Resolves #195 

In the 1.7.0 release checking that the function `has_header_video` is available before using it was overlooked. This PR adds `function_exists()` checks for `has_header_video` where necessary.

Additionally a minor PHPCS error was resolved (associative arrays on individual lines), which was introduced with the latest release of PHPCS.