### PR TITLE
Fix backward compatibility when using Beaver Builder on PHP 5.3 or lower

### DIFF
--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -172,9 +172,7 @@ class Primer_Customizer_Layouts {
 		 *
 		 * @var array
 		 */
-		$post_types = (array) apply_filters( 'primer_layouts_post_types', get_post_types( array(
-			'public' => true,
-		) ) );
+		$post_types = (array) apply_filters( 'primer_layouts_post_types', get_post_types( array( 'public' => true ) ) );
 
 		foreach ( $post_types as $post_type ) {
 

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -573,7 +573,7 @@ class Primer_Customizer_Layouts {
 	 *
 	 * @param  string $name Name of private property to retreive.
 	 *
-	 * @return string Return the specified property within the `Primer_Customizer_Colors` class.
+	 * @return string Return the specified property within the `Primer_Customizer_Layouts` class.
 	 */
 	public function __get( $name ) {
 

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -569,21 +569,17 @@ class Primer_Customizer_Layouts {
 	/**
 	 * Magic getter for `$colors` and `$color_schemes` properties.
 	 *
-	 * @since  1.0.0
+	 * @since  NEXT
 	 *
-	 * @param  string $name Color key or color scheme slug name.
+	 * @param  string $name Name of private property to retreive.
 	 *
 	 * @return string Return the specified property within the `Primer_Customizer_Colors` class.
 	 */
 	public function __get( $name ) {
 
-		if ( ! in_array( $name, array( 'layouts', 'default', 'meta_box', 'page_widths' ), true ) ) {
+		$properties = array( 'layouts', 'default', 'meta_box', 'page_widths' );
 
-			return false;
-
-		}
-
-		return $this->$name;
+		return in_array( $name, $properties, true ) ? $this->name : false;
 
 	}
 

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -15,7 +15,7 @@ class Primer_Customizer_Layouts {
 	 *
 	 * @var array
 	 */
-	protected $layouts = array();
+	public $layouts = array();
 
 	/**
 	 * Default layout key.
@@ -172,7 +172,9 @@ class Primer_Customizer_Layouts {
 		 *
 		 * @var array
 		 */
-		$post_types = (array) apply_filters( 'primer_layouts_post_types', get_post_types( array( 'public' => true ) ) );
+		$post_types = (array) apply_filters( 'primer_layouts_post_types', get_post_types( array(
+			'public' => true,
+		) ) );
 
 		foreach ( $post_types as $post_type ) {
 
@@ -561,6 +563,27 @@ class Primer_Customizer_Layouts {
 		$layout = (string) apply_filters( 'primer_current_layout', $layout, $post );
 
 		return $this->layout_exists( $layout ) ? $layout : $this->default;
+
+	}
+
+	/**
+	 * Magic getter for `$colors` and `$color_schemes` properties.
+	 *
+	 * @since  1.0.0
+	 *
+	 * @param  string $name Color key or color scheme slug name.
+	 *
+	 * @return string Return the specified property within the `Primer_Customizer_Colors` class.
+	 */
+	public function __get( $name ) {
+
+		if ( ! in_array( $name, array( 'layouts', 'default', 'meta_box', 'page_widths' ), true ) ) {
+
+			return false;
+
+		}
+
+		return $this->$name;
 
 	}
 

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -15,7 +15,7 @@ class Primer_Customizer_Layouts {
 	 *
 	 * @var array
 	 */
-	public $layouts = array();
+	protected $layouts = array();
 
 	/**
 	 * Default layout key.

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -576,7 +576,9 @@ function primer_array_replace_recursive( array $array1, array $array2 ) {
 
 	if ( function_exists( 'array_replace_recursive' ) ) {
 
-		return call_user_func_array( 'array_replace_recursive', func_get_args() );
+		$args = func_get_args();
+
+		return call_user_func_array( 'array_replace_recursive', $args );
 
 	}
 


### PR DESCRIPTION
Resolves #196 

Enables backwards compatibility for Beaver Builder. 

Tested and working back to **PHP v5.2.4** ([Beaver Builder minimum requirement](http://kb.wpbeaverbuilder.com/article/253-system-requirements-for-beaver-builder))