### PR TITLE
WooCommerce pagination template @version dockblock

### DIFF
--- a/templates/woocommerce/loop/pagination.php
+++ b/templates/woocommerce/loop/pagination.php
@@ -6,6 +6,8 @@
  *
  * @package Primer
  * @since   1.6.0
+ *
+ * @version 2.2.2
  */
 
 global $wp_query;


### PR DESCRIPTION
The WooCommerce template file, [pagination.php](https://github.com/godaddy/wp-primer-theme/blob/develop/templates/woocommerce/loop/pagination.php#L1-L9), was missing a version dockblock. 

This caused an error to be thrown on the WooCommerce system status page for the template.

**Before:**
![Exampe](https://cldup.com/P5RaVtKGzw.png) 

**After:**
![Exampe](https://cldup.com/moL1yUfzX6.png) 