### PR TITLE
Tweak .site-title-wrapper width on mobile devices

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -30,6 +30,7 @@ body.no-max-width .site-header-wrapper {
 	padding: 6% 1rem;
 
 	@media #{$small-only} {
+		max-width: 87.22222%;
 		padding-left: 0.75rem;
 		padding-right: 0.75rem;
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1669,6 +1669,7 @@ body.no-max-width .site-header-wrapper {
   padding: 6% 1rem; }
   @media only screen and (max-width: 40.063em) {
     .site-title-wrapper {
+      max-width: 87.22222%;
       padding-right: 0.75rem;
       padding-left: 0.75rem; } }
 

--- a/style.css
+++ b/style.css
@@ -1669,6 +1669,7 @@ body.no-max-width .site-header-wrapper {
   padding: 6% 1rem; }
   @media only screen and (max-width: 40.063em) {
     .site-title-wrapper {
+      max-width: 87.22222%;
       padding-left: 0.75rem;
       padding-right: 0.75rem; } }
 


### PR DESCRIPTION
This PR prevents the `.site-title-wrapper` element from being 97% width and overlapping onto the hamburger icon.

**Before patch:**
![Before Patch](https://cldup.com/zPQL_Hy-J3.png)

**After patch:**
![After Patch](https://cldup.com/g0TiBKIJ0v.png)