### PR TITLE
Inline font styles not enqueued properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - source $DEV_LIB_PATH/travis.install.sh
   - curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar > /tmp/wp-cli.phar
   - chmod +x /tmp/wp-cli.phar
+  - phpcs --version
 
 script:
   - source $DEV_LIB_PATH/travis.script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ install:
   - source $DEV_LIB_PATH/travis.install.sh
   - curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar > /tmp/wp-cli.phar
   - chmod +x /tmp/wp-cli.phar
-  - phpcs --version
 
 script:
   - source $DEV_LIB_PATH/travis.script.sh

--- a/inc/customizer/fonts.php
+++ b/inc/customizer/fonts.php
@@ -388,7 +388,7 @@ class Primer_Customizer_Fonts {
 				$this->get_font( $name )
 			);
 
-			wp_add_inline_style( Primer_Customizer::$stylesheet . '-fonts', $css );
+			wp_add_inline_style( Primer_Customizer::$stylesheet, $css );
 
 		}
 


### PR DESCRIPTION
Resolves #216 
Resolves https://github.com/godaddy/wp-mins-theme/issues/38

This bug effects the loading of fonts within Primer & Primer child themes.

The issue here is that Primer attempts to enqueue a set of inline styles once the stylesheet `$theme-fonts` (ie, for mins this was `mins-fonts`) which was never actually enqueued.

Remove the `-font` suffix from the theme handle has the fonts enqueuing properly, once again.