### PR TITLE
Update docs build order, fixing the blank contributors page.

### DIFF
--- a/.dev/docs/apigen/hook-docs.php
+++ b/.dev/docs/apigen/hook-docs.php
@@ -359,6 +359,13 @@ class Primer_Hook_Finder {
 
 		echo '</div><div id="footer">';
 
+		if ( ! is_dir( '../sphinx/src/documentation/' ) ) {
+
+			// dir doesn't exist, make it
+			mkdir( '../sphinx/src/documentation/' );
+
+		}
+
 		file_put_contents( '../sphinx/src/documentation/hook-docs.html', ob_get_clean() );
 
 		echo "Primer Hook documentation successfully generated!\n";

--- a/.dev/docs/sphinx/src/contributors.md
+++ b/.dev/docs/sphinx/src/contributors.md
@@ -1,2 +1,12 @@
 ## Contributors
 
+<section class="contributor-container"><a href="https://github.com/fjarrett" target="_blank"><img src="https://avatars1.githubusercontent.com/u/522158?v=3" class="contributor-image" /> <br />fjarrett</a></section>
+<section class="contributor-container"><a href="https://github.com/jonathanbardo" target="_blank"><img src="https://avatars3.githubusercontent.com/u/1933681?v=3" class="contributor-image" /> <br />jonathanbardo</a></section>
+<section class="contributor-container"><a href="https://github.com/chriswallace" target="_blank"><img src="https://avatars0.githubusercontent.com/u/80830?v=3" class="contributor-image" /> <br />chriswallace</a></section>
+<section class="contributor-container"><a href="https://github.com/schrapel" target="_blank"><img src="https://avatars1.githubusercontent.com/u/3613405?v=3" class="contributor-image" /> <br />schrapel</a></section>
+<section class="contributor-container"><a href="https://github.com/EvanHerman" target="_blank"><img src="https://avatars1.githubusercontent.com/u/5321364?v=3" class="contributor-image" /> <br />EvanHerman</a></section>
+<section class="contributor-container"><a href="https://github.com/lukapaunovic" target="_blank"><img src="https://avatars0.githubusercontent.com/u/23408913?v=3" class="contributor-image" /> <br />lukapaunovic</a></section>
+<section class="contributor-container"><a href="https://github.com/christianc1" target="_blank"><img src="https://avatars3.githubusercontent.com/u/5025568?v=3" class="contributor-image" /> <br />christianc1</a></section>
+<section class="contributor-container"><a href="https://github.com/gmays" target="_blank"><img src="https://avatars1.githubusercontent.com/u/6279639?v=3" class="contributor-image" /> <br />gmays</a></section>
+<section class="contributor-container"><a href="https://github.com/wpexplorer" target="_blank"><img src="https://avatars0.githubusercontent.com/u/1128841?v=3" class="contributor-image" /> <br />wpexplorer</a></section>
+<section class="contributor-container"><a href="https://github.com/garand" target="_blank"><img src="https://avatars1.githubusercontent.com/u/82437?v=3" class="contributor-image" /> <br />garand</a></section>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -315,10 +315,11 @@ module.exports = function( grunt ) {
 				'make html'
 			].join( ' && ' ),
 			docs: [
-				'apigen generate --config .dev/docs/apigen/apigen.neon',
 				'cd .dev/docs/apigen',
 				'php contributor-list.php',
-				'php hook-docs.php'
+				'php hook-docs.php',
+				'cd ../../../',
+				'apigen generate --config .dev/docs/apigen/apigen.neon',
 			].join( ' && ' ),
 			deploy_docs: [
 				'cd .dev/docs/build/html',


### PR DESCRIPTION
The [contributors page](https://godaddy.github.io/wp-primer-theme/contributors.html) in the documentation was being overwritten during the `update-docs` & `deploy-docs` tasks, ultimately leaving us with a blank page. 

This PR reorders the documentation build process so that the `contributors.md` page is built first, and the rest of the documentation is built around it - preventing the overwrite.