### PR TITLE
Re-enable the default layout option in the customizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
 
 install:
   - export DEV_LIB_PATH=.dev/dev-lib
+  - DEV_LIB_SKIP=phpcs
   - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
   - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
   - source $DEV_LIB_PATH/travis.install.sh

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -60,9 +60,34 @@ class Primer_Customizer {
 		require_once get_template_directory() . '/inc/customizer/static-front-page.php';
 
 		add_action( 'after_setup_theme',      array( $this, 'logo' ) );
+		add_action( 'customize_register',     array( $this, 'require_controls' ), 1 );
 		add_action( 'customize_register',     array( $this, 'selective_refresh' ), 11 );
 		add_action( 'customize_register',     array( $this, 'use_featured_hero_image' ) );
 		add_action( 'customize_preview_init', array( $this, 'customize_preview_js' ) );
+
+	}
+
+	/**
+	 * Include controls class required by our sections.
+	 *
+	 * This is hooked her since WP_Customize_Control is not present before.
+	 */
+	public function require_controls() {
+
+		/**
+		 * Autoload all customizer controls.
+		 *
+		 * @since 1.0.0
+		 */
+		foreach( glob( dirname( __FILE__ ) . '/customizer/controls/*.php' ) as $filename ) {
+
+			if ( is_readable( $filename ) ) {
+
+				require_once $filename;
+
+			}
+
+		}
 
 	}
 

--- a/inc/customizer/controls/layouts.php
+++ b/inc/customizer/controls/layouts.php
@@ -1,0 +1,85 @@
+<?php
+
+class Primer_Customizer_Layouts_Control extends WP_Customize_Control {
+
+	/**
+	 * Enqueue some custom css for layout control.
+	 *
+	 * @since 1.0.0
+	 */
+	public function enqueue() {
+
+		$rtl    = is_rtl() ? '-rtl' : '';
+		$suffix = SCRIPT_DEBUG ? '' : '.min';
+
+		wp_enqueue_style(
+			'primer-layouts',
+			get_template_directory_uri() . "/assets/css/admin/layouts{$rtl}{$suffix}.css",
+			array(),
+			PRIMER_VERSION
+		);
+
+		wp_enqueue_script(
+			'primer-layouts',
+			get_template_directory_uri() . "/assets/js/admin/layouts{$suffix}.js",
+			array( 'customize-controls' ),
+			true
+		);
+
+		$layouts = array();
+
+		/**
+		 * Identify which layouts are in the same category
+		 */
+		foreach ( $this->choices as $key => $label ) {
+
+			list( $number ) = explode( '-', $key );
+
+			$layouts[ $key ] = $number;
+
+		}
+
+		/**
+		 * Filter layouts transport mechanism in the customizer. Either postMessage or refresh.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @var array
+		 */
+		$layouts = (array) apply_filters( 'primer_layouts_transport', $layouts );
+
+		wp_localize_script(
+			'primer-layouts',
+			'primer_layouts_transport',
+			$layouts
+		);
+
+	}
+
+	/**
+	 * Display layout choices in the Customizer.
+	 *
+	 * @global Primer_Customizer_Layouts $primer_customizer_layouts
+	 * @since 1.0.0
+	 */
+	protected function render_content() {
+
+		global $primer_customizer_layouts;
+
+		if ( ! empty( $this->label ) ) {
+
+			printf( '<span class="customize-control-title">%s</span>', esc_html( $this->label ) );
+
+		}
+
+		if ( ! empty( $this->description ) ) {
+
+			printf( '<span class="description customize-control-description">%s</span>', esc_html( $this->description ) );
+
+		}
+
+		$primer_customizer_layouts->print_layout_choices( $this->choices );
+
+	}
+
+}

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -429,6 +429,32 @@ class Primer_Customizer_Layouts {
 			)
 		);
 
+		$wp_customize->add_setting(
+			'layout',
+			array(
+				'default'           => get_theme_mod( 'layout', $this->default ),
+				'type'              => 'theme_mod',
+				'capability'        => 'edit_theme_options',
+				'sanitize_callback' => 'sanitize_html_class',
+				'transport'         => 'postMessage',
+			)
+		);
+
+		$wp_customize->add_control(
+			new Primer_Customizer_Layouts_Control(
+				$wp_customize,
+				'layout',
+				array(
+					'label'       => esc_html__( 'Default Layout', 'primer' ),
+					'description' => esc_html__( 'All posts and pages on your site will use this layout by default.', 'primer' ),
+					'section'     => 'layout',
+					'settings'    => 'layout',
+					'type'        => 'radio',
+					'choices'     => $this->layouts,
+				)
+			)
+		);
+
 		if ( ! $this->page_widths ) {
 
 			return;


### PR DESCRIPTION
Resolves #226 

This PR re-enables the default template selection inside of the customizer. This was removed in a previous PR, but without this option users are unable to update the default template option without using a filter.

Additionally, in a [recent commit to wp-dev-lib](https://github.com/xwp/wp-dev-lib/commit/cdf5dacb6396de8e5b9f2498678b591ef30ba559#diff-4c7bf58aee545a2be2ce9e3779921d6fR293) `phpcs.xml.dist` is now supported and triggers PHPCS in our build process, which is throwing a few errors:
https://travis-ci.org/godaddy/wp-primer-theme/builds/259868092

**Customizer:**
![Example](https://cldup.com/gnZThZN-Ay.png)
