### PR TITLE
Add replace:charset to the watch:sass Grunt.js task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -337,7 +337,7 @@ module.exports = function( grunt ) {
 			},
 			sass: {
 				files: '.dev/sass/**/*.scss',
-				tasks: [ 'sass', 'autoprefixer', 'cssjanus', 'cssmin' ]
+				tasks: [ 'sass', 'autoprefixer', 'cssjanus', 'cssmin', 'replace:charset' ]
 			}
 		},
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -337,7 +337,7 @@ module.exports = function( grunt ) {
 			},
 			sass: {
 				files: '.dev/sass/**/*.scss',
-				tasks: [ 'sass', 'autoprefixer', 'cssjanus', 'cssmin', 'replace:charset' ]
+				tasks: [ 'sass', 'replace:charset', 'autoprefixer', 'cssjanus', 'cssmin' ]
 			}
 		},
 


### PR DESCRIPTION
While `grunt:watch` is running, each time a sass file is processed `@charset "UTF-8";` exists at the top of the `style.css` file until the default `grunt` task is run.

Adding `replace:charset` to the `watch:sass` task will prevent the charset from being appended to the top of the style file.