### PR TITLE
Ensure backwards compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: precise
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ language:
   - node_js
 
 php:
+  - 5.3
   - 5.6
   - 7.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: false
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ after_script:
 jobs:
   fast_finish: true
   exclude:
+    - php: 5.3
+      env: WP_VERSION=trunk
     - php: 5.6
       env: WP_VERSION=trunk
     - php: 7.1

--- a/inc/customizer/layouts.php
+++ b/inc/customizer/layouts.php
@@ -212,9 +212,9 @@ class Primer_Customizer_Layouts {
 
 		if ( isset( $post->ID ) ) {
 
-			wp_localize_script( 'primer-layouts', 'primerLayouts', [
+			wp_localize_script( 'primer-layouts', 'primerLayouts', array(
 				'selected' => $this->get_post_layout( $post->ID ),
-			] );
+			) );
 
 		}
 


### PR DESCRIPTION
- Revert shorthand array `[]` back to `array()` to ensure backwards compatibility with PHP < 5.6
- Re-enable PHP 5.3 in Travis