### PR TITLE
Google fonts should always load over https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ jobs:
   fast_finish: true
   exclude:
     - php: 5.3
+      env: WP_VERSION=latest
+    - php: 5.3
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_VERSION=trunk

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ install:
   - export DEV_LIB_PATH=.dev/dev-lib
   - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
   - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
-  - source $DEV_LIB_PATH/travis.install.sh
+  - source $DEV_LIB_PATH/scripts/travis.install.sh
 
 script:
-  - source $DEV_LIB_PATH/travis.script.sh
+  - source $DEV_LIB_PATH/scripts/travis.script.sh
 
 after_script:
-  - source $DEV_LIB_PATH/travis.after_script.sh
+  - source $DEV_LIB_PATH/scripts/travis.after_script.sh
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ language: php
 php:
   - 5.3
   - 5.6
-  - 7.1
+  - 7.2
 
 env:
   global:
@@ -35,16 +35,14 @@ before_install:
 
 install:
   - nvm install 6 && nvm use 6
-  - export DEV_LIB_PATH=.dev/dev-lib
-  - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
-  - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
-  - source $DEV_LIB_PATH/scripts/travis.install.sh
+  - export DEV_LIB_PATH=.dev/dev-lib/scripts
+  - source $DEV_LIB_PATH/travis.install.sh
 
 script:
-  - source $DEV_LIB_PATH/scripts/travis.script.sh
+  - source $DEV_LIB_PATH/travis.script.sh
 
 after_script:
-  - source $DEV_LIB_PATH/scripts/travis.after_script.sh
+  - source $DEV_LIB_PATH/travis.after_script.sh
 
 jobs:
   fast_finish: true
@@ -53,11 +51,13 @@ jobs:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_VERSION=trunk
-    - php: 7.1
+    - php: 5.6
+      env: WP_VERSION=4.4
+    - php: 7.2
       env: WP_VERSION=4.4
   include:
     - stage: theme check
-      php: 7.1
+      php: 7.2
       env: WP_VERSION=latest
       install:
         - export THEME_CHECK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ language: php
 php:
   - 5.3
   - 5.6
-  - 7.2
+  - 7.3
 
 env:
   global:
@@ -55,11 +55,11 @@ jobs:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_VERSION=4.4
-    - php: 7.2
+    - php: 7.3
       env: WP_VERSION=4.4
   include:
     - stage: theme check
-      php: 7.2
+      php: 7.3
       env: WP_VERSION=latest
       install:
         - export THEME_CHECK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 language: php
 
 php:
-  - 5.3
+  - 5.4
   - 5.6
   - 7.3
 
@@ -47,9 +47,9 @@ after_script:
 jobs:
   fast_finish: true
   exclude:
-    - php: 5.3
+    - php: 5.4
       env: WP_VERSION=latest
-    - php: 5.3
+    - php: 5.4
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_VERSION=trunk

--- a/inc/customizer/fonts.php
+++ b/inc/customizer/fonts.php
@@ -367,7 +367,7 @@ class Primer_Customizer_Fonts {
 			)
 		);
 
-		wp_enqueue_style( Primer_Customizer::$stylesheet . '-fonts', add_query_arg( $query_args, '//fonts.googleapis.com/css' ), false );
+		wp_enqueue_style( Primer_Customizer::$stylesheet . '-fonts', add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ), false );
 
 	}
 

--- a/inc/customizer/fonts.php
+++ b/inc/customizer/fonts.php
@@ -367,7 +367,7 @@ class Primer_Customizer_Fonts {
 			)
 		);
 
-		wp_enqueue_style( Primer_Customizer::$stylesheet . '-fonts', add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ), false );
+		wp_enqueue_style( Primer_Customizer::$stylesheet . '-fonts', add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ), array(), PRIMER_VERSION, 'all' );
 
 	}
 


### PR DESCRIPTION
@EvanHerman please review

Not explicitly using https can result in 307 internal redirect responses and force the request to transmit over http/1.1.

**BEFORE**
<img width="851" alt="screenshot 2019-02-17 11 17 12" src="https://user-images.githubusercontent.com/522158/52917195-b0e06780-32a5-11e9-88f8-2ca37c5ac3be.png">

**AFTER**
<img width="837" alt="screenshot 2019-02-17 11 03 19" src="https://user-images.githubusercontent.com/522158/52917193-ae7e0d80-32a5-11e9-962d-bf370388936e.png">
