### PR TITLE
Add style tweaks for the Contact Widgets block

### DIFF
--- a/.dev/sass/blocks/blocks.scss
+++ b/.dev/sass/blocks/blocks.scss
@@ -2,6 +2,7 @@
 @import "button";
 @import "coblocks";
 @import "columns";
+@import "contact-widgets";
 @import "cover";
 @import "embed";
 @import "gallery";

--- a/.dev/sass/blocks/contact-widgets.scss
+++ b/.dev/sass/blocks/contact-widgets.scss
@@ -1,0 +1,17 @@
+.wp-block-contact-widgets-contact-block {
+
+	> ul {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+
+
+		li {
+			margin-bottom: 1rem;
+		}
+	}
+
+	.has-map {
+		margin-top: 1rem;
+	}
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -651,6 +651,16 @@ a {
   .has-3-columns .wp-block-column:nth-child(3n) {
     margin-left: 0 !important; } }
 
+.wp-block-contact-widgets-contact-block > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+  .wp-block-contact-widgets-contact-block > ul li {
+    margin-bottom: 1rem; }
+
+.wp-block-contact-widgets-contact-block .has-map {
+  margin-top: 1rem; }
+
 .wp-block-cover {
   margin-bottom: 2em;
   margin-top: 2em; }

--- a/style.css
+++ b/style.css
@@ -651,6 +651,16 @@ a {
   .has-3-columns .wp-block-column:nth-child(3n) {
     margin-right: 0 !important; } }
 
+.wp-block-contact-widgets-contact-block > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+  .wp-block-contact-widgets-contact-block > ul li {
+    margin-bottom: 1rem; }
+
+.wp-block-contact-widgets-contact-block .has-map {
+  margin-top: 1rem; }
+
 .wp-block-cover {
   margin-bottom: 2em;
   margin-top: 2em; }


### PR DESCRIPTION
The Contact Widgets block required a few minor style adjustments: 

**Before:** 
<img width="996" alt="before" src="https://user-images.githubusercontent.com/1813435/58983575-27e23300-87a5-11e9-9ae5-c81af16148ee.png">

**After:** 
<img width="998" alt="after" src="https://user-images.githubusercontent.com/1813435/58983589-2d3f7d80-87a5-11e9-86ca-4dbbdf0fb0e4.png">
