### PR TITLE
Remove incorrect use of rel=author from footer

### DIFF
--- a/templates/parts/credit.php
+++ b/templates/parts/credit.php
@@ -57,7 +57,7 @@
 			esc_html__( '%1$s WordPress theme by %2$s', 'primer' ),
 			esc_html( $theme->get( 'Name' ) ),
 			sprintf(
-				'<a href="%s" rel="author nofollow">%s</a>',
+				'<a href="%s" rel="nofollow">%s</a>',
 				esc_url( $theme->get( 'AuthorURI' ) ),
 				esc_html( $theme->get( 'Author' ) )
 			)


### PR DESCRIPTION
The author rel shouldn't be used here, as it can incorrectly cause the site to become attributed to GoDaddy as the content author.